### PR TITLE
feat: package deduplication

### DIFF
--- a/packages/metro-resolver/src/FailedToResolveNameError.js
+++ b/packages/metro-resolver/src/FailedToResolveNameError.js
@@ -13,25 +13,17 @@
 const path = require('path');
 
 class FailedToResolveNameError extends Error {
-  dirPaths: $ReadOnlyArray<string>;
-  extraPaths: $ReadOnlyArray<string>;
+  modulePaths: $ReadOnlyArray<string>;
 
-  constructor(
-    dirPaths: $ReadOnlyArray<string>,
-    extraPaths: $ReadOnlyArray<string>,
-  ) {
-    const displayDirPaths = dirPaths.concat(extraPaths);
-    const hint = displayDirPaths.length ? ' or in these directories:' : '';
+  constructor(modulePaths: $ReadOnlyArray<string>) {
+    const hint = modulePaths.length ? ' or at these locations:' : '';
     super(
       `Module does not exist in the Haste module map${hint}\n` +
-        displayDirPaths
-          .map(dirPath => `  ${path.dirname(dirPath)}\n`)
-          .join(', ') +
+        modulePaths.map(modulePath => `  ${modulePath}\n`).join(', ') +
         '\n',
     );
 
-    this.dirPaths = dirPaths;
-    this.extraPaths = extraPaths;
+    this.modulePaths = modulePaths;
   }
 }
 

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -421,12 +421,16 @@ function isRelativeImport(filePath: string) {
 }
 
 function normalizePath(modulePath) {
+  const wasRelative = isRelativeImport(modulePath);
   if (path.sep === '/') {
     modulePath = path.normalize(modulePath);
   } else if (path.posix) {
     modulePath = path.posix.normalize(modulePath);
   }
-
+  // Ensure `normalize` cannot strip leading "./"
+  if (wasRelative && modulePath[0] !== '.') {
+    modulePath = './' + modulePath;
+  }
   return modulePath.replace(/\/$/, '');
 }
 

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -102,9 +102,10 @@ function resolve(
   const modulePaths = [];
   for (let packagePath of genPackagePaths(context, parsedName)) {
     packagePath = context.redirectPackage(packagePath);
-    const modulePath = context.redirectModulePath(
-      path.join(packagePath, parsedName.file),
-    );
+    const modulePath = parsedName.file
+      ? context.redirectModulePath(path.join(packagePath, parsedName.file))
+      : packagePath;
+
     const result = resolveFileOrDir(context, modulePath, platform);
     if (result.type === 'resolved') {
       return result.resolution;

--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -90,45 +90,74 @@ function resolve(
         return resolution;
       }
     } catch (error) {}
-  }
-
-  const dirPaths = [];
-  for (
-    let currDir = path.dirname(originModulePath);
-    currDir !== '.' && currDir !== path.parse(originModulePath).root;
-    currDir = path.dirname(currDir)
-  ) {
-    const searchPath = path.join(currDir, 'node_modules');
-    dirPaths.push(path.join(searchPath, realModuleName));
-  }
-
-  const extraPaths = [];
-  const {extraNodeModules} = context;
-  if (extraNodeModules) {
-    let bits = path.normalize(moduleName).split(path.sep);
-    let packageName;
-    // Normalize packageName and bits for scoped modules
-    if (bits.length >= 2 && bits[0].startsWith('@')) {
-      packageName = bits.slice(0, 2).join('/');
-      bits = bits.slice(1);
-    } else {
-      packageName = bits[0];
-    }
-    if (extraNodeModules[packageName]) {
-      bits[0] = extraNodeModules[packageName];
-      extraPaths.push(path.join.apply(path, bits));
+    if (isDirectImport) {
+      throw new Error('Failed to resolve module: ' + realModuleName);
     }
   }
 
-  const allDirPaths = dirPaths.concat(extraPaths);
-  for (let i = 0; i < allDirPaths.length; ++i) {
-    const realModuleName = context.redirectModulePath(allDirPaths[i]);
-    const result = resolveFileOrDir(context, realModuleName, platform);
+  const modulePaths = [];
+  for (let modulePath of genModulePaths(context, realModuleName)) {
+    modulePath = context.redirectModulePath(modulePath);
+
+    const result = resolveFileOrDir(context, modulePath, platform);
     if (result.type === 'resolved') {
       return result.resolution;
     }
+
+    modulePaths.push(modulePath);
   }
-  throw new FailedToResolveNameError(dirPaths, extraPaths);
+  throw new FailedToResolveNameError(modulePaths);
+}
+
+/** Generate the potential module paths */
+function* genModulePaths(
+  context: ResolutionContext,
+  toModuleName: string,
+): Iterable<string> {
+  const {extraNodeModules, follow, originModulePath} = context;
+
+  /**
+   * Extract the scope and package name from the module name.
+   */
+  let bits = path.normalize(toModuleName).split(path.sep);
+  let packageName, scopeName;
+  if (bits.length >= 2 && bits[0].startsWith('@')) {
+    packageName = bits.slice(0, 2).join('/');
+    scopeName = bits[0];
+    bits = bits.slice(2);
+  } else {
+    packageName = bits.shift();
+  }
+
+  /**
+   * Find the nearest "node_modules" directory that contains
+   * the imported package.
+   */
+  const {root} = path.parse(originModulePath);
+  let parent = originModulePath;
+  do {
+    parent = path.dirname(parent);
+    if (path.basename(parent) !== 'node_modules') {
+      yield path.join(
+        follow(path.join(parent, 'node_modules', packageName)),
+        ...bits,
+      );
+    }
+  } while (parent !== root);
+
+  /**
+   * Check the user-provided `extraNodeModules` module map for a
+   * direct mapping to a directory that contains the imported package.
+   */
+  if (extraNodeModules) {
+    parent =
+      extraNodeModules[packageName] ||
+      (scopeName ? extraNodeModules[scopeName] : void 0);
+
+    if (parent) {
+      yield path.join(follow(path.join(parent, packageName)), ...bits);
+    }
+  }
 }
 
 /**

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -90,12 +90,6 @@ export type HasteContext = FileOrDirContext & {
    * a Haste module of that name. Ex. for `Foo` it may return `/smth/Foo.js`.
    */
   +resolveHasteModule: (name: string) => ?string,
-  /**
-   * Given a name, this should return the full path to the package manifest that
-   * provides a Haste package of that name. Ex. for `Foo` it may return
-   * `/smth/Foo/package.json`.
-   */
-  +resolveHastePackage: (name: string) => ?string,
 };
 
 export type ModulePathContext = FileOrDirContext & {
@@ -110,7 +104,7 @@ export type ResolutionContext = ModulePathContext &
   HasteContext & {
     allowHaste: boolean,
     extraNodeModules: ?{[string]: string},
-    originModulePath: string,
+    redirectPackage: (packagePath: string) => string,
     resolveRequest?: ?CustomResolver,
     follow: FollowFn,
   };

--- a/packages/metro-resolver/src/types.js
+++ b/packages/metro-resolver/src/types.js
@@ -48,6 +48,7 @@ export type FileCandidates =
  */
 export type DoesFileExist = (filePath: string) => boolean;
 export type IsAssetFile = (fileName: string) => boolean;
+export type FollowFn = (filePath: string) => string;
 
 /**
  * Given a directory path and the base asset name, return a list of all the
@@ -111,6 +112,7 @@ export type ResolutionContext = ModulePathContext &
     extraNodeModules: ?{[string]: string},
     originModulePath: string,
     resolveRequest?: ?CustomResolver,
+    follow: FollowFn,
   };
 
 export type CustomResolver = (

--- a/packages/metro/src/ModuleGraph/node-haste/node-haste.js
+++ b/packages/metro/src/ModuleGraph/node-haste/node-haste.js
@@ -143,6 +143,7 @@ exports.createResolveFn = function(options: ResolveOptions): ResolveFn {
     dirExists: (filePath: string): boolean => hasteFS.dirExists(filePath),
     doesFileExist: (filePath: string): boolean => hasteFS.exists(filePath),
     extraNodeModules,
+    follow: (filePath: string): string => hasteFS.follow(filePath),
     isAssetFile: (filePath: string): boolean => helpers.isAssetFile(filePath),
     mainFields: options.mainFields,
     moduleCache,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -90,6 +90,7 @@ class DependencyGraph extends EventEmitter {
       resetCache: config.resetCache,
       rootDir: config.projectRoot,
       roots: config.watchFolders,
+      skipPackageJson: true,
       throwOnModuleCollision: true,
       useWatchman: config.resolver.useWatchman,
       watch: true,

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -143,6 +143,7 @@ class DependencyGraph extends EventEmitter {
 
   _createModuleResolver() {
     this._moduleResolver = new ModuleResolver({
+      follow: (filePath: string) => this._hasteFS.follow(filePath),
       dirExists: (filePath: string) => {
         try {
           return fs.lstatSync(filePath).isDirectory();

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -117,9 +117,9 @@ class DependencyGraph extends EventEmitter {
   }
 
   _getClosestPackage(filePath: string): ?string {
-    const parsedPath = path.parse(filePath);
-    const root = parsedPath.root;
-    let dir = parsedPath.dir;
+    const {root} = path.parse(filePath);
+    // The `filePath` may be a directory.
+    let dir = filePath;
     do {
       const candidate = path.join(dir, 'package.json');
       if (this._hasteFS.exists(candidate)) {

--- a/packages/metro/src/node-haste/DependencyGraph/ResolutionRequest.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ResolutionRequest.js
@@ -22,6 +22,7 @@ import type {ModuleResolver} from './ModuleResolution';
 
 export type Packageish = {
   path: string,
+  root: string,
   redirectRequire(
     toModuleName: string,
     mainFields: $ReadOnlyArray<string>,

--- a/packages/metro/src/node-haste/Package.js
+++ b/packages/metro/src/node-haste/Package.js
@@ -13,8 +13,9 @@
 const fs = require('fs');
 const path = require('path');
 
-type PackageContent = {
+export type PackageContent = {
   name: string,
+  version: string,
   'react-native': mixed,
   browser: mixed,
   main: ?string,
@@ -22,14 +23,13 @@ type PackageContent = {
 
 class Package {
   path: string;
-
-  _root: string;
-  _content: ?PackageContent;
+  root: string;
+  content: ?PackageContent;
 
   constructor({file}: {file: string}) {
     this.path = path.resolve(file);
-    this._root = path.dirname(this.path);
-    this._content = null;
+    this.root = path.dirname(this.path);
+    this.content = null;
   }
 
   /**
@@ -76,11 +76,11 @@ class Package {
     }
 
     /* $FlowFixMe: `getReplacements` doesn't validate the return value. */
-    return path.join(this._root, main);
+    return path.join(this.root, main);
   }
 
   invalidate() {
-    this._content = null;
+    this.content = null;
   }
 
   redirectRequire(
@@ -101,7 +101,7 @@ class Package {
     }
 
     let relPath =
-      './' + path.relative(this._root, path.resolve(this._root, name));
+      './' + path.relative(this.root, path.resolve(this.root, name));
 
     if (path.sep !== '/') {
       relPath = relPath.replace(new RegExp('\\' + path.sep, 'g'), '/');
@@ -123,17 +123,17 @@ class Package {
     }
 
     if (redirect) {
-      return path.join(this._root, redirect);
+      return path.join(this.root, redirect);
     }
 
     return name;
   }
 
   read(): PackageContent {
-    if (this._content == null) {
-      this._content = JSON.parse(fs.readFileSync(this.path, 'utf8'));
+    if (this.content == null) {
+      this.content = JSON.parse(fs.readFileSync(this.path, 'utf8'));
     }
-    return this._content;
+    return this.content;
   }
 }
 

--- a/packages/metro/src/node-haste/types.js
+++ b/packages/metro/src/node-haste/types.js
@@ -13,6 +13,7 @@
 // TODO(cpojer): Create a jest-types repo.
 export type HasteFS = {
   exists(filePath: string): boolean,
+  follow(filePath: string): string,
   getAllFiles(): Array<string>,
   getFileIterator(): Iterator<string>,
   getModuleName(filePath: string): ?string,


### PR DESCRIPTION
### Summary

This PR is a follow-up to #350. It deduplicates packages with the same name/version pair. 🎉 

- Disable `throwOnModuleCollision` for jest-haste-map
- Enable `skipHastePackages` for jest-haste-map (https://github.com/facebook/jest/pull/7778)
- Remove the `resolveHastePackage` function
- Change `ModuleCache#getPackage` to use an existing package if it has the same `name` and `version`
- Change `ModuleCache#processFileChange` to update the `"name@version" => package` map
- Various refactoring

Only https://github.com/facebook/metro/commit/e29c4855fc8d356992b308220e6b889618b32a56 is relevant to this PR. The others are from #257.

### Test plan

No time to write tests, currently. 😢 

I've tested this manually. Works great so far! 😃 