### PR TITLE
Add mac as a platform in Platform.select inline

### DIFF
--- a/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
+++ b/packages/metro/src/JSTransformer/worker/__tests__/inline-plugin-test.js
@@ -296,6 +296,19 @@ describe('inline constants', () => {
     });
   });
 
+  it('inlines Platform.select in the code to ios and mac if both are present and running on ios platform', () => {
+    const code = `
+      function a() {
+        var a = Platform.select({ios: 1, android: 2, mac: 3});
+      }
+    `;
+
+    compare([inlinePlugin], code, code.replace(' android: 2,', ''), {
+      inlinePlatform: 'true',
+      platform: 'ios',
+    });
+  });
+
   it('does not inline Platform.select in the code when some of the properties are dynamic', () => {
     const code = `
       function a() {
@@ -334,6 +347,32 @@ describe('inline constants', () => {
     compare([inlinePlugin], code, code, {
       inlinePlatform: true,
       platform: 'android',
+    });
+  });
+
+  it('does not inline Platform.select if the current platform is ios, and ios and mac are in the properties', () => {
+    const code = `
+      function a() {
+        var a = Platform.select({ios: 1, mac: 2});
+      }
+    `;
+
+    compare([inlinePlugin], code, code, {
+      inlinePlatform: true,
+      platform: 'ios',
+    });
+  });
+
+  it('does not inline Platform.select if the current platform is ios and mac is in the properties, but ios is not', () => {
+    const code = `
+      function a() {
+        var a = Platform.select({mac: 1, default: 2});
+      }
+    `;
+
+    compare([inlinePlugin], code, code, {
+      inlinePlatform: true,
+      platform: 'ios',
     });
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Related to https://github.com/facebook/react-native/pull/27484. Once this PR will be merged, I'll send a PR to also support `Platform.select` with `mac` in React Native.

This adds support for mac as a platform in `Platform.select` inline.

Mac is not properly a platform, but we should be able to target it with `Platform.select`. I'm not sure if this is a good idea or not, but it seems to me. 🤔 

#### Inlines `Platform.select` in the code to `ios` and `mac` if both are present and running on `ios` platform

```javascript
function a() {
  var a = Platform.select({ios: 1, android: 2, mac: 3});
}
```

Inlines into:

```javascript
function a() {
  var a = Platform.select({ios: 1, mac: 3});
}
```

#### Doesn't inline `Platform.select` if the current platform is `ios`, and `ios` and `mac` are in the properties

```javascript
function a() {
  var a = Platform.select({ios: 1, mac: 2});
}
```

Stays the same, as we're running on iOS, and we don't know if we're on macOS or not.

#### Doesn't inline `Platform.select` if the current platform is `ios` and `mac` is in the properties, but `ios` is not

```javascript
function a() {
  var a = Platform.select({mac: 1, default: 2});
}
```

Stays the same, as the `ios` platform could either be using `mac` or `default` for iOS.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

See changes in tests.
