### PR TITLE
Customize module not found error message when on windows

### DIFF
--- a/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
+++ b/packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -217,10 +217,18 @@ class ModuleResolver<TModule: Moduleish, TPackage: Packageish> {
               (dirPath: string) => `  ${path.dirname(dirPath)}`,
             ),
             '\nIf you are sure the module exists, try these steps:',
-            ' 1. Clear watchman watches: watchman watch-del-all',
-            ' 2. Delete node_modules and run yarn install',
-            " 3. Reset Metro's cache: yarn start --reset-cache",
-            ' 4. Remove the cache: rm -rf /tmp/metro-*',
+            ...(process.platform === 'win32'
+              ? [
+                  ' 1. Delete node_modules and run yarn install',
+                  " 2. Reset Metro's cache: yarn start --reset-cache",
+                  ' 3. Remove the cache: for /d %i in (%Temp%\\metro-*) do rd /s /q %i',
+                ]
+              : [
+                  ' 1. Clear watchman watches: watchman watch-del-all',
+                  ' 2. Delete node_modules and run yarn install',
+                  " 3. Reset Metro's cache: yarn start --reset-cache",
+                  ' 4. Remove the cache: rm -rf /tmp/metro-*',
+                ]),
           ].join('\n'),
         );
       }


### PR DESCRIPTION
**Summary**

The error message that metro displays when it fails to resolve a module doesn't make sense on windows.  The first option involves running watchman, which doesn't run on windows.  And the last steps involves running some bash commands that don't exist on a default windows install.

So I'm changing what the message is when running on windows.

**Test plan**


