### PR TITLE
Implement postProcessBundleSourcemap option

### DIFF
--- a/packages/metro-config/src/configTypes.flow.js
+++ b/packages/metro-config/src/configTypes.flow.js
@@ -38,13 +38,12 @@ export type PostMinifyProcess = ({
 };
 
 export type PostProcessBundleSourcemap = ({
-  code: Buffer | string,
+  code: string,
   map: MixedSourceMap,
-  outFileName: string,
   ...
 }) => {
-  code: Buffer | string,
-  map: MixedSourceMap | string,
+  code: string,
+  map: MixedSourceMap,
   ...
 };
 

--- a/packages/metro-config/src/defaults/index.js
+++ b/packages/metro-config/src/defaults/index.js
@@ -51,7 +51,7 @@ const getDefaultValues = (projectRoot: ?string): ConfigT => ({
     getRunModuleStatement: (moduleId: number | string) =>
       `__r(${JSON.stringify(moduleId)});`,
     getPolyfills: () => [],
-    postProcessBundleSourcemap: ({code, map, outFileName}) => ({code, map}),
+    postProcessBundleSourcemap: ({code, map}) => ({code, map}),
     getModulesRunBeforeMainModule: () => [],
     processModuleFilter: module => true,
     createModuleIdFactory: defaultCreateModuleIdFactory,

--- a/packages/metro/src/index.js
+++ b/packages/metro/src/index.js
@@ -306,6 +306,7 @@ exports.runBuild = async (
       platform,
       sourceMapUrl: sourceMap === false ? undefined : sourceMapUrl,
       createModuleIdFactory: config.serializer.createModuleIdFactory,
+      postProcessBundleSourcemap: config.serializer.postProcessBundleSourcemap,
       onProgress,
     };
 

--- a/packages/metro/src/shared/output/__tests__/__snapshots__/bundle-test.js.snap
+++ b/packages/metro/src/shared/output/__tests__/__snapshots__/bundle-test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should call postProcessBundleSourcemap 1`] = `
+Object {
+  "code": "modified code",
+  "map": "{\\"ast\\":\\"some code\\"}",
+}
+`;
+
+exports[`should succeed 1`] = `
+Object {
+  "code": "code",
+  "map": "{\\"ast\\":\\"some code\\"}",
+}
+`;

--- a/packages/metro/src/shared/output/__tests__/bundle-test.js
+++ b/packages/metro/src/shared/output/__tests__/bundle-test.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @emails oncall+js_foundation
+ * @flow
+ */
+
+'use strict';
+
+jest.mock(
+  '../../../Server',
+  () =>
+    class MockServer {
+      build() {
+        return Promise.resolve({code: 'code', map: '{"ast":"some code"}'});
+      }
+    },
+);
+
+const bundle = require('../bundle');
+const Server = require('../../../Server');
+const {getDefaultValues} = require('metro-config/src/defaults');
+const config = getDefaultValues('/');
+const requestOptions = {
+  entryFile: 'test',
+  minify: false,
+  platform: 'ios',
+};
+
+it('should succeed', async () => {
+  expect(
+    await bundle.build(new Server(config), {...requestOptions}),
+  ).toMatchSnapshot();
+});
+
+it('should call postProcessBundleSourcemap', async () => {
+  const postProcessBundleSourcemap = jest.fn(({code, map}) => ({
+    code: `modified ${code}`,
+    map,
+  }));
+  expect(
+    await bundle.build(new Server(config), {
+      ...requestOptions,
+      postProcessBundleSourcemap,
+    }),
+  ).toMatchSnapshot();
+  expect(postProcessBundleSourcemap).toBeCalled();
+});

--- a/packages/metro/src/shared/types.flow.js
+++ b/packages/metro/src/shared/types.flow.js
@@ -128,7 +128,18 @@ export type RequestOptions = {|
   minify: boolean,
   platform: string,
   createModuleIdFactory?: () => (path: string) => number,
+  postProcessBundleSourcemap?: PostProcessBundleSourcemap,
   onProgress?: (transformedFileCount: number, totalFileCount: number) => void,
 |};
 
 export type {MinifierOptions};
+
+export type PostProcessBundleSourcemap = ({
+  code: string,
+  map: MixedSourceMap,
+  ...
+}) => {
+  code: string,
+  map: MixedSourceMap,
+  ...
+};


### PR DESCRIPTION
**Summary**

#400 

I implemented `PostProcessBundleSourcemap` option, which is on document but not in current code.
With this, we can modify processed code, which makes making plugins easier.

I took a look to the original code https://github.com/facebook/metro/commit/cd67cd47941a942509a360bac3d8a11c5ce070ff#diff-660c08c7ccb569e12d8a268bd8fa2011?w=1

I fixed `PostProcessBundleSourcemap` type to fit current code.

**Test plan**

I added `bundle-test.js`, to test postProcessBundleSourcemap works.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
