### PR TITLE
Use absolute path to project root as a component of cache key

### DIFF
--- a/packages/metro/src/DeltaBundler/getTransformCacheKey.js
+++ b/packages/metro/src/DeltaBundler/getTransformCacheKey.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const path = require('path');
 const crypto = require('crypto');
 const getCacheKey = require('metro-cache-key');
 
@@ -42,6 +43,7 @@ function getTransformCacheKey(opts: {|
         'metro-cache',
         VERSION,
         opts.cacheVersion,
+        path.resolve(path.join(__dirname, '../../..'), opts.projectRoot),
         getCacheKey([require.resolve(transformerPath)]),
         transformerKey,
         transformerConfig.globalPrefix,


### PR DESCRIPTION
Problem in question was initially observed with `metro@0.58.0` and `react-native@0.63.4`

`getTransformCacheKey` produces same cache key for projects located
in different paths (while having all other configs equal).

When running several builds on CI computer I noticed strange failures
happening randomly which looked like this (every time with different
files):

```
error Unable to resolve module `/something/FOLDER_1/packages/app/src/reactotron-config` from `packages/app/src/app/init/loggers.ts`:
None of these files exist:
   * /something/FOLDER_1/packages/app/src/reactotron-config(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.svg|.native.svg|.svg)
   * /something/FOLDER_1/packages/app/src/reactotron-config/index(.native|.ios.js|.native.js|.js|.ios.json|.native.json|.json|.ios.ts|.native.ts|.ts|.ios.tsx|.native.tsx|.tsx|.ios.svg|.native.svg|.svg). Run CLI with --verbose flag for more details.
```

The problem here is that the process which caught this error was
launched from `/something/FOLDER_2/...` - two independent bundle
commands shared the cache.

This could also be reproduced locally when running two
`react-native bundle --reset-cache ...` instances from different folder.

I was able to fix this on our side by doing
`cacheVersion: "1.0-" + __dirname`  in `metro.config.js`

But I believe that cache components should account for an absolute path
of the project.

Previous commits introducing and then removing path to a project:

1. https://github.com/facebook/metro/commit/2322db4f819fde85bcb8867e1ef6ceb860b15ef4
2. https://github.com/facebook/metro/commit/c2dfe747b50457f870fe2afb79d0df6a0499f209



<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->