### PR TITLE
Add stubs for experimental dev-mode bundle splitting to asyncRequire

### DIFF
--- a/packages/metro-runtime/src/modules/asyncRequire.js
+++ b/packages/metro-runtime/src/modules/asyncRequire.js
@@ -12,6 +12,20 @@
 
 // $FlowExpectedError Flow does not know about Metro's require extensions.
 const dynamicRequire = (require: {importAll: mixed => mixed});
-module.exports = function(moduleID: mixed): Promise<mixed> {
+function asyncRequire(moduleID: mixed): Promise<mixed> {
   return Promise.resolve().then(() => dynamicRequire.importAll(moduleID));
+}
+
+asyncRequire.prefetch = function(moduleID: number, moduleName: string): void {};
+
+asyncRequire.resource = function(moduleID: number, moduleName: string): empty {
+  throw new Error('Not implemented');
 };
+
+asyncRequire.addImportBundleNames = function(importBundleNames: mixed): void {
+  throw new Error(
+    'This bundle was compiled with transformer.experimentalImportBundleSupport=true but is using an incompatible version of asyncRequire.',
+  );
+};
+
+module.exports = asyncRequire;


### PR DESCRIPTION
Summary: Adds stubs that allow Metro bundles to error gracefully if `experimentalImportBundleSupport: true` is used without swapping out `asyncRequire` for a compatible implementation.

Differential Revision: D30579830

