### PR TITLE
Fix platform inline transform for babel esmodules commonjs transform output

### DIFF
--- a/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
@@ -795,6 +795,60 @@ describe('inline constants', () => {
     );
   });
 
+  it('can work with transformed import calls', () => {
+    const code = `
+      __arbitrary(require, function(arbitraryMapName) {
+        var _reactNative = require(arbitraryMapName[123]);
+
+        function a() {
+          if (_reactNative.Platform.OS === 'android') {
+            a = function() {};
+          }
+
+          var b = a.Platform.OS;
+        }
+      });
+    `;
+
+    compare(
+      [inlinePlugin],
+      code,
+      code.replace(/_reactNative\.Platform\.OS/, '"ios"'),
+      {
+        inlinePlatform: true,
+        platform: 'ios',
+        isWrapped: true,
+      },
+    );
+  });
+
+  it('can work with transformed import calls numbered', () => {
+    const code = `
+      __arbitrary($$require, function(arbitraryMapName) {
+        var _reactNative2 = $$require(arbitraryMapName[123]);
+
+        function a() {
+          if (_reactNative2.Platform.OS === 'android') {
+            a = function() {};
+          }
+
+          var b = a.Platform.OS;
+        }
+      });
+    `;
+
+    compare(
+      [inlinePlugin],
+      code,
+      code.replace(/_reactNative2\.Platform\.OS/, '"ios"'),
+      {
+        inlinePlatform: true,
+        platform: 'ios',
+        isWrapped: true,
+      },
+    );
+  });
+
   it('works with flow-declared variables', () => {
     const code = `
       declare var __DEV__;


### PR DESCRIPTION
## Summary

I noticed that when using esmodule named import of platform dead code elimination of Platform.OS did not work.

#### Does not work

Source:
```js
import { Platform } from 'react-native';

if (Platform.OS === 'android') {
  // code
}
```
Transformed:
```js
var _reactNative = _$$_REQUIRE(_dependencyMap[4]);

if (_reactNative.Platform.OS !== 'android') {
  // code
}

```


#### Works

Source:
```js
const { Platform } = require('react-native');

if (Platform.OS === 'android') {
  // code
}
```
Transformed:
```js
var _require = _$$_REQUIRE(_dependencyMap[4]),
Platform = _require.Platform;

if ('ios' !== 'android') {
  // code
}
```

The inline plugin works on transformed and bundled code. For the working `require` case it works since `Platform` is assigned to a top level variable, which the plugin considers as valid for inlining. In the case of `import` babel transforms it to a single top level require call (`_reactNative`), but the name doesn't match any of the allowed ones (`ReactNative`, `React`). This means it is not considered valid for inlining.

The name of the variable seems based on the name of the module imported, so `react-native` becomes `_reactNative`. I also noticed some cases in an app bundle where babel will add a number suffix to the variable like `_reactNative2`. This seems to be cause by other imports containing the name `react-native` like `@sentry/react-native`.

To support both cases I added support for passing a regex to the valid top level binding names. We can then use this to match `_reactNative` + optional number.

## Test plan

Added a test for the case similar to how code looks in the transformed bundle before being passed to the inline plugin. Also tested this in an app bundle and looked for instances of `Platform.OS` than should be inlined and made sure there was none.
