### PR TITLE
feat(config): support typescript configs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -3,11 +3,13 @@ id: configuration
 title: Configuring Metro
 ---
 
-A Metro config can be created in these three ways (ordered by priority):
+A Metro config can be created in these five ways (ordered by priority):
 
 1.  `metro.config.js`
-2.  `metro.config.json`
-3.  The `metro` field in `package.json`
+2.  `metro.config.ts`
+3.  `metro.config.cjs`
+4.  `metro.config.json`
+5.  The `metro` field in `package.json`
 
 You can also give a custom file to the configuration by specifying `--config <path/to/config>` when calling the CLI.
 

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "connect": "^3.6.5",
     "cosmiconfig": "^5.0.5",
+    "cosmiconfig-typescript-loader": "^5.0.0",
     "jest-validate": "^29.6.3",
     "metro": "0.80.6",
     "metro-cache": "0.80.6",

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -16,6 +16,8 @@ import type {ConfigT, InputConfigT, YargArguments} from './configTypes.flow';
 const getDefaultConfig = require('./defaults');
 const validConfig = require('./defaults/validConfig');
 const cosmiconfig = require('cosmiconfig');
+const cosmiconfigTypeScriptLoader =
+  require('cosmiconfig-typescript-loader').TypeScriptLoader;
 const fs = require('fs');
 const {validate} = require('jest-validate');
 const MetroCache = require('metro-cache');
@@ -48,11 +50,13 @@ function overrideArgument<T>(arg: Array<T> | T): T {
 const explorer = cosmiconfig('metro', {
   searchPlaces: [
     'metro.config.js',
+    'metro.config.ts',
     'metro.config.cjs',
     'metro.config.json',
     'package.json',
   ],
   loaders: {
+    '.ts': cosmiconfigTypeScriptLoader(),
     '.json': cosmiconfig.loadJson,
     '.yaml': cosmiconfig.loadYaml,
     '.yml': cosmiconfig.loadYaml,

--- a/packages/metro-config/src/loadConfig.js
+++ b/packages/metro-config/src/loadConfig.js
@@ -16,8 +16,7 @@ import type {ConfigT, InputConfigT, YargArguments} from './configTypes.flow';
 const getDefaultConfig = require('./defaults');
 const validConfig = require('./defaults/validConfig');
 const cosmiconfig = require('cosmiconfig');
-const cosmiconfigTypeScriptLoader =
-  require('cosmiconfig-typescript-loader').TypeScriptLoader;
+const {TypeScriptLoader} = require('cosmiconfig-typescript-loader');
 const fs = require('fs');
 const {validate} = require('jest-validate');
 const MetroCache = require('metro-cache');
@@ -56,7 +55,7 @@ const explorer = cosmiconfig('metro', {
     'package.json',
   ],
   loaders: {
-    '.ts': cosmiconfigTypeScriptLoader(),
+    '.ts': TypeScriptLoader(),
     '.json': cosmiconfig.loadJson,
     '.yaml': cosmiconfig.loadYaml,
     '.yml': cosmiconfig.loadYaml,

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -17,7 +17,6 @@ import type {InputConfigT} from 'metro-config/src/configTypes.flow';
 
 const {getDefaultConfig, mergeConfig} = require('metro-config');
 const path = require('path');
-const mockPlatform = process.platform;
 
 jest.useRealTimers();
 jest
@@ -26,7 +25,7 @@ jest
   .mock('os', () => ({
     ...jest.requireActual('os'),
     platform: () => 'test',
-    tmpdir: () => (mockPlatform === 'win32' ? 'C:\\tmp' : '/tmp'),
+    tmpdir: () => (process.platform === 'win32' ? 'C:\\tmp' : '/tmp'),
     hostname: () => 'testhost',
     endianness: () => 'LE',
     release: () => '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,6 +2629,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig-typescript-loader@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-5.0.0.tgz#0d3becfe022a871f7275ceb2397d692e06045dc8"
+  integrity sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==
+  dependencies:
+    jiti "^1.19.1"
+
 cosmiconfig@^5.0.5:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
@@ -4515,6 +4522,11 @@ jest@^29.6.3:
     "@jest/types" "^29.6.3"
     import-local "^3.0.2"
     jest-cli "^29.6.3"
+
+jiti@^1.19.1:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
+  integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
 js-sdsl@^4.1.4:
   version "4.4.2"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Allowing the user to user ts config will reduce configuration mistakes

I had to revert https://github.com/facebook/metro/commit/05b9ed4446c31c44f310fce1fbc86f3240084a85 as jiti uses os.tmpdir and it would conflict. But it seems to be running fine with node 18/20 at least

## Test plan

Unsure how to test this, but the code seems pretty straightforward
Happy to discuss if testing is needed
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
