### PR TITLE
fix(metro-resolver): use proper `isRelativeImport` check that works with Windows paths

### DIFF
--- a/packages/metro-resolver/src/resolve.js
+++ b/packages/metro-resolver/src/resolve.js
@@ -508,7 +508,7 @@ function resolveWindowsPath(modulePath: string) {
 }
 
 function isRelativeImport(filePath: string) {
-  return /^[.][.]?(?:[/]|$)/.test(filePath);
+  return /^[.][.]?(?:[/\\]|$)/.test(filePath);
 }
 
 function normalizePath(modulePath: any | string) {


### PR DESCRIPTION
## Summary

Found an issue with the `isRelativeImport` from the resolver on Windows, resulting in the following issues:
- https://github.com/expo/expo/issues/29631
- https://www.reddit.com/r/expo/comments/1dd43gb/unable_to_resolve_module_node/

The summary of this is that Expo resolves the `main` field from the package during [static rendering here](https://github.com/expo/expo/blob/88d15528e68e6119f84a9e2be5f23775c40bc03a/packages/%40expo/cli/src/start/server/metro/MetroBundlerDevServer.ts#L263). On Windows, it results in a path like `.\\node_modules\\expo-router\\entry`, which is correct. Node can resolve this path using `require.resolve`:

![image](https://github.com/facebook/metro/assets/1203991/6b23e4d2-c0ae-4dda-abef-4944d7a563ce)

Unfortunately, the `metro-resolver` can't handle this properly because of a single reason: `isRelativeImport` returns false for `.\\node_modules\\expo-router\\entry`, because the regex only tests posix paths, not Windows paths. It results in the following resolve chain:

1. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L52-L58) - `resolveModulePath` is never called, as this path is not absolute, and incorrectly marked as not relative either
2. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L60-L65) - `realModuleName` is also not false, as the module path is not redirected
3. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L67-L86) - `isDirectImport` also results in `false`, for the same reasons as 1
4. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L88-L94) - `context.allowHaste` is disabled during Expo static rendering
5. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L96-L129) - Both `disableHierarchicalLookup` and `extraNodeModules` aren't set by default in Expo projects.
6. [link](https://github.com/facebook/metro/blob/5c78f8d539474552b264626b5a99dc0d92243db3/packages/metro-resolver/src/resolve.js#L131-L147) - `allDirPaths` already contain `<project>\\node_modules`, and when joining with `.\\node_modules\\expo-router\\entry`, it creates paths with `<project>\\node_modules\\node_modules\\...`, which are also incorrect.

<details><summary>Overview of all values through the debugger</summary>

![image](https://github.com/facebook/metro/assets/1203991/8f248bd9-d732-42a3-92d5-22535cb76dcb)

</details>

This change adds the Windows path, as a valid path separator, to the `isRelativeImport` test - making it compatible with Windows.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Fix] Detect relative imports in the Metro Resolver correctly on Windows

## Test plan

Only reproducible on Windows.

- `$ npm create expo ./test-metro-resolve`
- `$ cd ./test-metro-resolve`
- `$ npx expo export --platform web`
- Failure due to the resolve issue I just mentioned

