### PR TITLE
Remove (NOBRIDGE) prefix from Metro logs

### DIFF
--- a/packages/metro/src/lib/TerminalReporter.js
+++ b/packages/metro/src/lib/TerminalReporter.js
@@ -261,7 +261,7 @@ class TerminalReporter {
         this._logHmrClientError(event.error);
         break;
       case 'client_log':
-        logToConsole(this.terminal, event.level, event.mode, ...event.data);
+        logToConsole(this.terminal, event.level, ...event.data);
         break;
       case 'unstable_server_log':
         const logFn = {

--- a/packages/metro/src/lib/__tests__/logToConsole-test.js
+++ b/packages/metro/src/lib/__tests__/logToConsole-test.js
@@ -33,9 +33,9 @@ beforeEach(() => {
 });
 
 test('invoke native console methods', () => {
-  log(console, 'log', 'BRIDGE', 'Banana');
-  log(console, 'warn', 'BRIDGE', 'Apple');
-  log(console, 'warn', 'BRIDGE', 'Kiwi');
+  log(console, 'log', 'Banana');
+  log(console, 'warn', 'Apple');
+  log(console, 'warn', 'Kiwi');
   jest.runAllTimers();
 
   expect(console.log).toHaveBeenNthCalledWith(1, ' LOG ', 'Banana');
@@ -44,22 +44,22 @@ test('invoke native console methods', () => {
 });
 
 test('removes excess whitespace', () => {
-  log(console, 'log', 'BRIDGE', 'Banana\n   ');
+  log(console, 'log', 'Banana\n   ');
   jest.runAllTimers();
 
   expect(console.log).toHaveBeenNthCalledWith(1, ' LOG ', 'Banana');
 });
 
 test('ignore `groupCollapsed` calls', () => {
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
+  log(console, 'groupCollapsed');
+  log(console, 'groupEnd');
   jest.runAllTimers();
 
   expect(console.log).not.toHaveBeenCalled();
 });
 
 test('warn if `groupCollapsed` and `groupEnd` are not balanced', () => {
-  log(console, 'groupCollapsed', 'BRIDGE');
+  log(console, 'groupCollapsed');
   jest.runAllTimers();
 
   expect(console.log).toHaveBeenCalledWith(
@@ -68,47 +68,47 @@ test('warn if `groupCollapsed` and `groupEnd` are not balanced', () => {
   );
 
   // Ensure that the console resets the state and will accept new logs
-  log(console, 'warn', 'BRIDGE', 'Apple');
+  log(console, 'warn', 'Apple');
   jest.runAllTimers();
   expect(console.log).toHaveBeenCalledWith(' WARN ', 'Apple');
 });
 
 test('can deal with nested `group` and `groupCollapsed` calls', () => {
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'group', 'BRIDGE');
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
+  log(console, 'groupCollapsed');
+  log(console, 'group');
+  log(console, 'groupCollapsed');
+  log(console, 'groupEnd');
+  log(console, 'groupEnd');
+  log(console, 'groupEnd');
   jest.runAllTimers();
 
   expect(console.log).not.toHaveBeenCalled();
 
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'group', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
+  log(console, 'groupCollapsed');
+  log(console, 'group');
+  log(console, 'groupEnd');
+  log(console, 'groupCollapsed');
+  log(console, 'groupEnd');
+  log(console, 'groupEnd');
   jest.runAllTimers();
 
   expect(console.log).not.toHaveBeenCalled();
 
-  log(console, 'group', 'BRIDGE');
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
+  log(console, 'group');
+  log(console, 'groupCollapsed');
+  log(console, 'groupEnd');
+  log(console, 'groupCollapsed');
+  log(console, 'groupEnd');
+  log(console, 'groupEnd');
   jest.runAllTimers();
 
   expect(console.log).toHaveBeenCalledTimes(1);
 
-  log(console, 'groupCollapsed', 'BRIDGE');
-  log(console, 'group', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'groupEnd', 'BRIDGE');
-  log(console, 'log', 'BRIDGE', 'Banana');
+  log(console, 'groupCollapsed');
+  log(console, 'group');
+  log(console, 'groupEnd');
+  log(console, 'groupEnd');
+  log(console, 'log', 'Banana');
   jest.runAllTimers();
 
   expect(console.log).toHaveBeenCalledTimes(2);

--- a/packages/metro/src/lib/logToConsole.js
+++ b/packages/metro/src/lib/logToConsole.js
@@ -20,12 +20,7 @@ const util = require('util');
 const groupStack = [];
 let collapsedGuardTimer;
 
-module.exports = (
-  terminal: Terminal,
-  level: string,
-  mode: 'BRIDGE' | 'NOBRIDGE',
-  ...data: Array<mixed>
-) => {
+module.exports = (terminal: Terminal, level: string, ...data: Array<mixed>) => {
   // $FlowFixMe[invalid-computed-prop]
   const logFunction = console[level] && level !== 'trace' ? level : 'log';
   const color =
@@ -66,10 +61,8 @@ module.exports = (
       data[data.length - 1] = lastItem.trimEnd();
     }
 
-    const modePrefix =
-      !mode || mode == 'BRIDGE' ? '' : `(${mode.toUpperCase()}) `;
     terminal.log(
-      color.bold(` ${modePrefix}${logFunction.toUpperCase()} `) +
+      color.bold(` ${logFunction.toUpperCase()} `) +
         ''.padEnd(groupStack.length * 2, ' '),
       // `util.format` actually accepts any arguments.
       // If the first argument is a string, it tries to format it.


### PR DESCRIPTION
Summary: Removes the mode and (NOBRIDGE) prefix to Metro's console logger.

Differential Revision: D79730914


