### PR TITLE
Remove `syntax-class-properties` Babel plugin, lock dedupe

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -22,7 +22,6 @@ const plugins = [
   'babel-plugin-transform-flow-enums',
   '@babel/plugin-transform-flow-strip-types',
   '@babel/plugin-transform-modules-commonjs',
-  '@babel/plugin-syntax-class-properties',
   '@babel/plugin-transform-react-jsx',
 ];
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@babel/plugin-syntax-class-properties": "^7.12.13",
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
     "@babel/plugin-transform-modules-commonjs": "^7.24.8",
     "@babel/plugin-transform-react-jsx": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -240,7 +240,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.12.13", "@babel/plugin-syntax-class-properties@^7.8.3":
+"@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz#b5c987274c4a3a82b89714796931a6b53544ae10"
   integrity sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Babel should be already able to parse class properties syntax out of the box with the version used in the workspace nad packages. 

Refs:
* https://babeljs.io/docs/babel-plugin-syntax-class-properties/

After removal, I have also run yarn deduplicate tool to clean up lock and make sure there are no leftovers.

<!--
Changelog entries should be prefixed with one of the following scopes:
[Breaking, Feature, Fix, Performance, Deprecated, Experimental, Internal]

Examples:
  Changelog: [Fix] Respond with HTTP 404 when a bundle entry point cannot be resolved
  Changelog: [Internal]
-->
Changelog: [Deprecated] Remove no longer needed `syntax-class-properties` Babel plugin

## Test plan

Running `yarn build`, `yarn build-ts-defs`, `yarn lint`, `yarn typecheck` yields no error. `yarn test` and `yarn test-smoke` checks are passing.
