### PR TITLE
metro-file-map: Don't emit directory events from watcher backends

### DIFF
--- a/packages/metro-file-map/src/watchers/FallbackWatcher.js
+++ b/packages/metro-file-map/src/watchers/FallbackWatcher.js
@@ -215,7 +215,8 @@ export default class FallbackWatcher extends AbstractWatcher {
     let closest: ?Readonly<{file: string, mtime: Stats['mtime']}> = null;
     let c = 0;
     Object.keys(this.#dirRegistry[dir]).forEach((file, i, arr) => {
-      fs.lstat(path.join(dir, file), (error, stat) => {
+      const absPath = path.join(dir, file);
+      fs.lstat(absPath, (error, stat) => {
         if (found) {
           return;
         }
@@ -284,17 +285,7 @@ export default class FallbackWatcher extends AbstractWatcher {
         recReaddir(
           path.resolve(this.root, relativePath),
           (dir, stats) => {
-            if (this.#watchdir(dir)) {
-              this.#emitEvent({
-                event: TOUCH_EVENT,
-                relativePath: path.relative(this.root, dir),
-                metadata: {
-                  modifiedTime: stats.mtime.getTime(),
-                  size: stats.size,
-                  type: 'd',
-                },
-              });
-            }
+            this.#watchdir(dir);
           },
           (file, stats) => {
             if (this.#register(file, 'f')) {

--- a/packages/metro-file-map/src/watchers/NativeWatcher.js
+++ b/packages/metro-file-map/src/watchers/NativeWatcher.js
@@ -108,7 +108,7 @@ export default class NativeWatcher extends AbstractWatcher {
       const type = typeFromStat(stat);
 
       // Ignore files of an unrecognized type
-      if (!type) {
+      if (!type || type === 'd') {
         return;
       }
 

--- a/packages/metro-file-map/src/watchers/WatchmanWatcher.js
+++ b/packages/metro-file-map/src/watchers/WatchmanWatcher.js
@@ -263,7 +263,7 @@ export default class WatchmanWatcher extends AbstractWatcher {
     );
 
     // Ignore files of an unrecognized type
-    if (type != null && !(type === 'f' || type === 'd' || type === 'l')) {
+    if (type != null && !(type === 'f' || type === 'l')) {
       return;
     }
 
@@ -292,22 +292,17 @@ export default class WatchmanWatcher extends AbstractWatcher {
         size,
       );
 
-      if (
-        // Change event on dirs are mostly useless.
-        !(type === 'd' && !isNew)
-      ) {
-        const mtime = Number(mtime_ms);
-        self.emitFileEvent({
-          event: TOUCH_EVENT,
-          clock,
-          relativePath,
-          metadata: {
-            modifiedTime: mtime !== 0 ? mtime : null,
-            size,
-            type,
-          },
-        });
-      }
+      const mtime = Number(mtime_ms);
+      self.emitFileEvent({
+        event: TOUCH_EVENT,
+        clock,
+        relativePath,
+        metadata: {
+          modifiedTime: mtime !== 0 ? mtime : null,
+          size,
+          type,
+        },
+      });
     }
   }
 

--- a/packages/metro-file-map/src/watchers/__tests__/helpers.js
+++ b/packages/metro-file-map/src/watchers/__tests__/helpers.js
@@ -42,7 +42,7 @@ const isWatchmanOnPath = () => {
 
 // `null` Watchers will be marked as skipped tests.
 export const WATCHERS: Readonly<{
-  [key: string]:
+  [key: 'Watchman' | 'Native' | 'Fallback']:
     | Class<FallbackWatcher>
     | Class<NativeWatcher>
     | Class<WatchmanWatcher>
@@ -94,7 +94,7 @@ export const createTempWatchRoot = async (
 };
 
 export const startWatching = async (
-  watcherName: string,
+  watcherName: keyof typeof WATCHERS,
   watchRoot: string,
   opts: WatcherOptions,
 ): (Promise<{


### PR DESCRIPTION
Summary:
We currently ignore all directory events downstream, so we can simplify the responsibilities of file watcher backends by not emitting directory events.

This is part of a refactoring where eventually we *do* want to emit consistent directory events, but we can have greater confidence by doing so only when in-memory "directories" (`Map`s ) are allocated/deleted in the in-memory filesystem.

Changelog: Internal

Differential Revision: D92053177


