### PR TITLE
refactor(metro-file-map): Pre-resolve symlink targets and store normal posix paths

### DIFF
--- a/packages/metro-file-map/src/crawlers/watchman/index.js
+++ b/packages/metro-file-map/src/crawlers/watchman/index.js
@@ -327,6 +327,12 @@ export default async function watchmanCrawl({
         if (fileData.type === 'l') {
           symlinkInfo = fileData['symlink_target'] ?? 1;
         }
+        if (typeof symlinkInfo === 'string') {
+          symlinkInfo = pathUtils.resolveSymlinkToNormal(
+            relativeFilePath,
+            symlinkInfo,
+          );
+        }
 
         const nextData: FileMetadata = [
           mtime,

--- a/packages/metro-file-map/src/crawlers/watchman/index.js
+++ b/packages/metro-file-map/src/crawlers/watchman/index.js
@@ -328,9 +328,8 @@ export default async function watchmanCrawl({
           symlinkInfo = fileData['symlink_target'] ?? 1;
         }
         if (typeof symlinkInfo === 'string') {
-          symlinkInfo = pathUtils.resolveSymlinkToNormal(
-            relativeFilePath,
-            symlinkInfo,
+          symlinkInfo = normalizePathSeparatorsToPosix(
+            pathUtils.resolveSymlinkToNormal(relativeFilePath, symlinkInfo),
           );
         }
 

--- a/packages/metro-file-map/src/crawlers/watchman/index.js
+++ b/packages/metro-file-map/src/crawlers/watchman/index.js
@@ -328,8 +328,9 @@ export default async function watchmanCrawl({
           symlinkInfo = fileData['symlink_target'] ?? 1;
         }
         if (typeof symlinkInfo === 'string') {
-          symlinkInfo = normalizePathSeparatorsToPosix(
-            pathUtils.resolveSymlinkToNormal(relativeFilePath, symlinkInfo),
+          symlinkInfo = pathUtils.resolveSymlinkToNormal(
+            relativeFilePath,
+            symlinkInfo,
           );
         }
 

--- a/packages/metro-file-map/src/flow-types.js
+++ b/packages/metro-file-map/src/flow-types.js
@@ -292,7 +292,8 @@ export type FileMetadata = [
   /* size */ number,
   /* visited */ 0 | 1,
   /* sha1 */ ?string,
-  /* symlink */ 0 | 1 | string, // string specifies target, if known
+  // A string is the symlink's target, resolved to a normal path, if known.
+  /* symlink */ 0 | 1 | string,
   /* plugindata */
   ...
 ];

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -155,7 +155,7 @@ export type {
 // This should be bumped whenever a code change to `metro-file-map` itself
 // would cause a change to the cache data structure and/or content (for a given
 // filesystem state and build parameters).
-const CACHE_BREAKER = '11';
+const CACHE_BREAKER = '12';
 
 const CHANGE_INTERVAL = 30;
 
@@ -565,7 +565,10 @@ export default class FileMap extends EventEmitter {
         .readlink(this.#pathUtils.normalToAbsolute(normalPath))
         .then(symlinkTarget => {
           fileMetadata[H.VISITED] = 1;
-          fileMetadata[H.SYMLINK] = symlinkTarget;
+          fileMetadata[H.SYMLINK] = this.#pathUtils.resolveSymlinkToNormal(
+            normalPath,
+            symlinkTarget,
+          );
         });
     }
     return null;

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -565,9 +565,8 @@ export default class FileMap extends EventEmitter {
         .readlink(this.#pathUtils.normalToAbsolute(normalPath))
         .then(symlinkTarget => {
           fileMetadata[H.VISITED] = 1;
-          fileMetadata[H.SYMLINK] = this.#pathUtils.resolveSymlinkToNormal(
-            normalPath,
-            symlinkTarget,
+          fileMetadata[H.SYMLINK] = normalizePathSeparatorsToPosix(
+            this.#pathUtils.resolveSymlinkToNormal(normalPath, symlinkTarget),
           );
         });
     }

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -592,8 +592,9 @@ export default class FileMap extends EventEmitter {
         .readlink(this.#pathUtils.normalToAbsolute(normalPath))
         .then(symlinkTarget => {
           fileMetadata[H.VISITED] = 1;
-          fileMetadata[H.SYMLINK] = normalizePathSeparatorsToPosix(
-            this.#pathUtils.resolveSymlinkToNormal(normalPath, symlinkTarget),
+          fileMetadata[H.SYMLINK] = this.#pathUtils.resolveSymlinkToNormal(
+            normalPath,
+            symlinkTarget,
           );
         });
     }

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -167,7 +167,7 @@ export type {
 // This should be bumped whenever a code change to `metro-file-map` itself
 // would cause a change to the cache data structure and/or content (for a given
 // filesystem state and build parameters).
-const CACHE_BREAKER = '11';
+const CACHE_BREAKER = '12';
 
 const CHANGE_INTERVAL = 30;
 
@@ -592,7 +592,10 @@ export default class FileMap extends EventEmitter {
         .readlink(this.#pathUtils.normalToAbsolute(normalPath))
         .then(symlinkTarget => {
           fileMetadata[H.VISITED] = 1;
-          fileMetadata[H.SYMLINK] = symlinkTarget;
+          fileMetadata[H.SYMLINK] = this.#pathUtils.resolveSymlinkToNormal(
+            normalPath,
+            symlinkTarget,
+          );
         });
     }
     return null;

--- a/packages/metro-file-map/src/index.js
+++ b/packages/metro-file-map/src/index.js
@@ -592,9 +592,8 @@ export default class FileMap extends EventEmitter {
         .readlink(this.#pathUtils.normalToAbsolute(normalPath))
         .then(symlinkTarget => {
           fileMetadata[H.VISITED] = 1;
-          fileMetadata[H.SYMLINK] = this.#pathUtils.resolveSymlinkToNormal(
-            normalPath,
-            symlinkTarget,
+          fileMetadata[H.SYMLINK] = normalizePathSeparatorsToPosix(
+            this.#pathUtils.resolveSymlinkToNormal(normalPath, symlinkTarget),
           );
         });
     }

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
 import invariant from 'invariant';
 import * as path from 'path';
 
@@ -164,6 +165,29 @@ export class RootPathUtils {
         ?.collapsedPath ??
       path.relative(this.#rootDir, path.join(this.#rootDir, relativePath))
     );
+  }
+
+  resolveSymlinkToNormal(
+    symlinkNormalPath: string,
+    readlinkResult: string,
+  ): string {
+    let target = normalizePathSeparatorsToSystem(readlinkResult);
+    // WARN: This only applies to Windows + Node 20 case, where the value is completely
+    // unnormalized and a trailing slash may be returned
+    if (target[target.length - 1] === path.sep) {
+      target = target.slice(0, -1);
+    }
+    if (path.isAbsolute(target)) {
+      return this.absoluteToNormal(target);
+    }
+    // Resolve relative to the symlink's containing directory, expressed as
+    // a root-relative (possibly non-normal) path, then normalize
+    const sepIdx = symlinkNormalPath.lastIndexOf(path.sep);
+    const rootRelativeTarget =
+      sepIdx === -1
+        ? target
+        : symlinkNormalPath.slice(0, sepIdx) + path.sep + target;
+    return this.relativeToNormal(rootRelativeTarget);
   }
 
   // If a path is a direct ancestor of the project root (or the root itself),

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -179,23 +179,24 @@ export class RootPathUtils {
     symlinkNormalPath: string,
     readlinkResult: string,
   ): string {
-    let target = normalizePathSeparatorsToSystem(readlinkResult);
-    // WARN: This only applies to Windows + Node 20 case, where the value is completely
-    // unnormalized and a trailing slash may be returned
-    if (target[target.length - 1] === path.sep) {
-      target = target.slice(0, -1);
-    }
+    const target = normalizePathSeparatorsToSystem(readlinkResult);
+    let normal;
     if (path.isAbsolute(target)) {
-      return this.absoluteToNormal(target);
+      normal = this.absoluteToNormal(target);
+    } else {
+      // Resolve relative to the symlink's containing directory, expressed as
+      // a root-relative (possibly non-normal) path, then normalize
+      const sepIdx = symlinkNormalPath.lastIndexOf(path.sep);
+      const rootRelativeTarget =
+        sepIdx === -1
+          ? target
+          : symlinkNormalPath.slice(0, sepIdx) + path.sep + target;
+      normal = this.relativeToNormal(rootRelativeTarget);
     }
-    // Resolve relative to the symlink's containing directory, expressed as
-    // a root-relative (possibly non-normal) path, then normalize
-    const sepIdx = symlinkNormalPath.lastIndexOf(path.sep);
-    const rootRelativeTarget =
-      sepIdx === -1
-        ? target
-        : symlinkNormalPath.slice(0, sepIdx) + path.sep + target;
-    return this.relativeToNormal(rootRelativeTarget);
+    // Normalization keeps a trailing separator when the result is the root or
+    // an ancestor of it (e.g. a link to '/'), and readlink itself may return
+    // one. A stored symlink target never has one.
+    return normal.endsWith(path.sep) ? normal.slice(0, -1) : normal;
   }
 
   // If a path is a direct ancestor of the project root (or the root itself),

--- a/packages/metro-file-map/src/lib/RootPathUtils.js
+++ b/packages/metro-file-map/src/lib/RootPathUtils.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
 import invariant from 'invariant';
 import * as path from 'node:path';
 
@@ -172,6 +173,29 @@ export class RootPathUtils {
         ?.collapsedPath ??
       path.relative(this.#rootDir, path.join(this.#rootDir, relativePath))
     );
+  }
+
+  resolveSymlinkToNormal(
+    symlinkNormalPath: string,
+    readlinkResult: string,
+  ): string {
+    let target = normalizePathSeparatorsToSystem(readlinkResult);
+    // WARN: This only applies to Windows + Node 20 case, where the value is completely
+    // unnormalized and a trailing slash may be returned
+    if (target[target.length - 1] === path.sep) {
+      target = target.slice(0, -1);
+    }
+    if (path.isAbsolute(target)) {
+      return this.absoluteToNormal(target);
+    }
+    // Resolve relative to the symlink's containing directory, expressed as
+    // a root-relative (possibly non-normal) path, then normalize
+    const sepIdx = symlinkNormalPath.lastIndexOf(path.sep);
+    const rootRelativeTarget =
+      sepIdx === -1
+        ? target
+        : symlinkNormalPath.slice(0, sepIdx) + path.sep + target;
+    return this.relativeToNormal(rootRelativeTarget);
   }
 
   // If a path is a direct ancestor of the project root (or the root itself),

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -21,6 +21,7 @@ import type {
 } from '../flow-types';
 
 import H from '../constants';
+import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
 import {RootPathUtils} from './RootPathUtils';
 import invariant from 'invariant';
 import path from 'path';
@@ -1212,11 +1213,12 @@ export default class TreeFS implements MutableFileSystem {
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
   ): NormalizedSymlinkTarget {
-    const symlinkTarget = symlinkNode[H.SYMLINK];
+    let symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
       typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
+    symlinkTarget = normalizePathSeparatorsToSystem(symlinkTarget);
     const result = {
       ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
       normalPath: symlinkTarget,

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -738,13 +738,13 @@ export default class TreeFS implements MutableFileSystem {
         // with the remaining path results in collapsing segments, e.g:
         // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
         // parentofroot and root as ancestors.
-        ancestorOfRootIdx =
-          this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget);
         if (
           collectAncestors &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
-          (ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0)
+          ((ancestorOfRootIdx =
+            this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget)) === 0 ||
+            joinedResult.collapsedSegments > 0)
         ) {
           let node: MixedNode = this.#rootNode;
           let collapsedPath = '';

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -38,12 +38,6 @@ function isRegularFile(node: FileNode): boolean {
   return node[H.SYMLINK] === 0;
 }
 
-type NormalizedSymlinkTarget = {
-  ancestorOfRootIdx: ?number,
-  normalPath: string,
-  startOfBasenameIdx: number,
-};
-
 type DeserializedSnapshotInput = {
   rootDir: string,
   fileSystemData: DirectoryNode,
@@ -728,7 +722,7 @@ export default class TreeFS implements MutableFileSystem {
         // Append any subsequent path segments to the symlink target, and reset
         // with our new target.
         const joinedResult = this.#pathUtils.joinNormalToRelative(
-          normalSymlinkTarget.normalPath,
+          normalSymlinkTarget,
           remainingTargetPath,
         );
 
@@ -744,12 +738,13 @@ export default class TreeFS implements MutableFileSystem {
         // with the remaining path results in collapsing segments, e.g:
         // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
         // parentofroot and root as ancestors.
+        ancestorOfRootIdx =
+          this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget);
         if (
           collectAncestors &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
-          (normalSymlinkTarget.ancestorOfRootIdx === 0 ||
-            joinedResult.collapsedSegments > 0)
+          (ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0)
         ) {
           let node: MixedNode = this.#rootNode;
           let collapsedPath = '';
@@ -764,7 +759,7 @@ export default class TreeFS implements MutableFileSystem {
               // Add the root only if the target is the root or we have
               // collapsed segments.
               i > 0 ||
-              normalSymlinkTarget.ancestorOfRootIdx === 0 ||
+              ancestorOfRootIdx === 0 ||
               joinedResult.collapsedSegments > 0
             ) {
               reverseAncestors.push({
@@ -787,7 +782,7 @@ export default class TreeFS implements MutableFileSystem {
         // the symlink target, and start collecting ancestors only
         // from the target itself (ie, the basename of the normal target path)
         // onwards.
-        unseenPathFromIdx = normalSymlinkTarget.startOfBasenameIdx;
+        unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path.sep) + 1;
 
         if (seen == null) {
           // Optimisation: set this lazily only when we've encountered a symlink
@@ -1212,19 +1207,13 @@ export default class TreeFS implements MutableFileSystem {
   #resolveSymlinkTargetToNormalPath(
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
-  ): NormalizedSymlinkTarget {
-    let symlinkTarget = symlinkNode[H.SYMLINK];
+  ): Path {
+    const symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
       typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
-    symlinkTarget = normalizePathSeparatorsToSystem(symlinkTarget);
-    const result = {
-      ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
-      normalPath: symlinkTarget,
-      startOfBasenameIdx: symlinkTarget.lastIndexOf(path.sep) + 1,
-    };
-    return result;
+    return normalizePathSeparatorsToSystem(symlinkTarget);
   }
 
   #getFileData(

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -124,8 +124,6 @@ type MetadataIteratorOptions = Readonly<{
  *   a trailing slash
  */
 export default class TreeFS implements MutableFileSystem {
-  +#cachedNormalSymlinkTargets: WeakMap<FileNode, NormalizedSymlinkTarget> =
-    new WeakMap();
   +#pathUtils: RootPathUtils;
   +#processFile: ProcessFileFunction;
   +#rootDir: Path;
@@ -1214,33 +1212,16 @@ export default class TreeFS implements MutableFileSystem {
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
   ): NormalizedSymlinkTarget {
-    const cachedResult = this.#cachedNormalSymlinkTargets.get(symlinkNode);
-    if (cachedResult != null) {
-      return cachedResult;
-    }
-
-    const literalSymlinkTarget = symlinkNode[H.SYMLINK];
+    const symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
-      typeof literalSymlinkTarget === 'string',
+      typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
-    const absoluteSymlinkTarget = path.resolve(
-      this.#rootDir,
-      canonicalPathOfSymlink,
-      '..', // Symlink target is relative to its containing directory.
-      literalSymlinkTarget, // May be absolute, in which case the above are ignored
-    );
-    const normalSymlinkTarget = path.relative(
-      this.#rootDir,
-      absoluteSymlinkTarget,
-    );
     const result = {
-      ancestorOfRootIdx:
-        this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget),
-      normalPath: normalSymlinkTarget,
-      startOfBasenameIdx: normalSymlinkTarget.lastIndexOf(path.sep) + 1,
+      ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
+      normalPath: symlinkTarget,
+      startOfBasenameIdx: symlinkTarget.lastIndexOf(path.sep) + 1,
     };
-    this.#cachedNormalSymlinkTargets.set(symlinkNode, result);
     return result;
   }
 

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -753,6 +753,8 @@ export default class TreeFS implements MutableFileSystem {
           collectAncestors &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
+          // Note that ancestorOfRootIdx is assigned here, so it is only up to
+          // date within this branch - the block below is its sole reader.
           ((ancestorOfRootIdx =
             this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget)) === 0 ||
             joinedResult.collapsedSegments > 0)

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -124,10 +124,6 @@ type MetadataIteratorOptions = Readonly<{
  *   a trailing slash
  */
 export default class TreeFS implements MutableFileSystem {
-  readonly #cachedNormalSymlinkTargets: WeakMap<
-    FileNode,
-    NormalizedSymlinkTarget,
-  > = new WeakMap();
   readonly #pathUtils: RootPathUtils;
   readonly #processFile: ProcessFileFunction;
   readonly #rootDir: Path;
@@ -1226,36 +1222,16 @@ export default class TreeFS implements MutableFileSystem {
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
   ): NormalizedSymlinkTarget {
-    const cachedResult = this.#cachedNormalSymlinkTargets.get(symlinkNode);
-    if (cachedResult != null) {
-      return cachedResult;
-    }
-
-    const literalSymlinkTarget = symlinkNode[H.SYMLINK];
+    const symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
-      typeof literalSymlinkTarget === 'string',
+      typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
-    let absoluteSymlinkTarget = path.resolve(
-      this.#rootDir,
-      canonicalPathOfSymlink,
-      '..', // Symlink target is relative to its containing directory.
-      literalSymlinkTarget, // May be absolute, in which case the above are ignored
-    );
-    if (absoluteSymlinkTarget.endsWith(path.sep)) {
-      absoluteSymlinkTarget = absoluteSymlinkTarget.slice(0, -1);
-    }
-    const normalSymlinkTarget = this.#pathUtils.absoluteToNormal(
-      absoluteSymlinkTarget,
-    );
-
     const result = {
-      ancestorOfRootIdx:
-        this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget),
-      normalPath: normalSymlinkTarget,
-      startOfBasenameIdx: normalSymlinkTarget.lastIndexOf(path.sep) + 1,
+      ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
+      normalPath: symlinkTarget,
+      startOfBasenameIdx: symlinkTarget.lastIndexOf(path.sep) + 1,
     };
-    this.#cachedNormalSymlinkTargets.set(symlinkNode, result);
     return result;
   }
 

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -38,12 +38,6 @@ function isRegularFile(node: FileNode): boolean {
   return node[H.SYMLINK] === 0;
 }
 
-type NormalizedSymlinkTarget = {
-  ancestorOfRootIdx: ?number,
-  normalPath: string,
-  startOfBasenameIdx: number,
-};
-
 type DeserializedSnapshotInput = {
   rootDir: string,
   fileSystemData: DirectoryNode,
@@ -738,7 +732,7 @@ export default class TreeFS implements MutableFileSystem {
         // Append any subsequent path segments to the symlink target, and reset
         // with our new target.
         const joinedResult = this.#pathUtils.joinNormalToRelative(
-          normalSymlinkTarget.normalPath,
+          normalSymlinkTarget,
           remainingTargetPath,
         );
 
@@ -754,12 +748,13 @@ export default class TreeFS implements MutableFileSystem {
         // with the remaining path results in collapsing segments, e.g:
         // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
         // parentofroot and root as ancestors.
+        ancestorOfRootIdx =
+          this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget);
         if (
           collectAncestors &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
-          (normalSymlinkTarget.ancestorOfRootIdx === 0 ||
-            joinedResult.collapsedSegments > 0)
+          (ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0)
         ) {
           let node: MixedNode = this.#rootNode;
           let collapsedPath = '';
@@ -774,7 +769,7 @@ export default class TreeFS implements MutableFileSystem {
               // Add the root only if the target is the root or we have
               // collapsed segments.
               i > 0 ||
-              normalSymlinkTarget.ancestorOfRootIdx === 0 ||
+              ancestorOfRootIdx === 0 ||
               joinedResult.collapsedSegments > 0
             ) {
               reverseAncestors.push({
@@ -797,7 +792,7 @@ export default class TreeFS implements MutableFileSystem {
         // the symlink target, and start collecting ancestors only
         // from the target itself (ie, the basename of the normal target path)
         // onwards.
-        unseenPathFromIdx = normalSymlinkTarget.startOfBasenameIdx;
+        unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path.sep) + 1;
 
         if (seen == null) {
           // Optimisation: set this lazily only when we've encountered a symlink
@@ -1222,19 +1217,13 @@ export default class TreeFS implements MutableFileSystem {
   #resolveSymlinkTargetToNormalPath(
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
-  ): NormalizedSymlinkTarget {
-    let symlinkTarget = symlinkNode[H.SYMLINK];
+  ): Path {
+    const symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
       typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
-    symlinkTarget = normalizePathSeparatorsToSystem(symlinkTarget);
-    const result = {
-      ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
-      normalPath: symlinkTarget,
-      startOfBasenameIdx: symlinkTarget.lastIndexOf(path.sep) + 1,
-    };
-    return result;
+    return normalizePathSeparatorsToSystem(symlinkTarget);
   }
 
   #getFileData(

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -21,7 +21,6 @@ import type {
 } from '../flow-types';
 
 import H from '../constants';
-import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
 import {RootPathUtils} from './RootPathUtils';
 import invariant from 'invariant';
 import path from 'node:path';
@@ -90,10 +89,10 @@ type MetadataIteratorOptions = Readonly<{
  *
  * SYMLINKS:
  *
- * Symlinks are represented as nodes whose metadata contains their literal
- * target. Literal targets are resolved to normal paths at runtime, and cached.
- * If a symlink is encountered during traversal, we restart traversal at the
- * root node targeting join(normal symlink target, remaining path suffix).
+ * Symlinks are represented as nodes whose metadata contains their target,
+ * already resolved to a normal path when the node was populated. If a symlink
+ * is encountered during traversal, we restart traversal at the root node
+ * targeting join(normal symlink target, remaining path suffix).
  *
  * NODE TYPES:
  *
@@ -102,8 +101,8 @@ type MetadataIteratorOptions = Readonly<{
  * - A file is represented by an `Array`  (tuple) of metadata, of which:
  *   - A regular file has node[H.SYMLINK] === 0
  *   - A symlink has node[H.SYMLINK] === 1 or
- *     typeof node[H.SYMLINK] === 'string', where a string is the literal
- *     content of the symlink (i.e. from readlink), if known.
+ *     typeof node[H.SYMLINK] === 'string', where a string is the target
+ *     resolved to a normal path, if known.
  *
  * TERMINOLOGY:
  *
@@ -714,10 +713,12 @@ export default class TreeFS implements MutableFileSystem {
           };
         }
 
-        // Symlink in a directory path
-        const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(
-          segmentNode,
-          currentPath,
+        // Symlink in a directory path. Targets are stored already resolved
+        // to a normal path, so this is a read rather than a computation.
+        const normalSymlinkTarget = segmentNode[H.SYMLINK];
+        invariant(
+          typeof normalSymlinkTarget === 'string',
+          'Expected symlink target to be populated.',
         );
         if (opts.collectLinkPaths) {
           opts.collectLinkPaths.add(
@@ -1212,18 +1213,6 @@ export default class TreeFS implements MutableFileSystem {
         );
       }
     }
-  }
-
-  #resolveSymlinkTargetToNormalPath(
-    symlinkNode: FileMetadata,
-    canonicalPathOfSymlink: Path,
-  ): Path {
-    const symlinkTarget = symlinkNode[H.SYMLINK];
-    invariant(
-      typeof symlinkTarget === 'string',
-      'Expected symlink target to be populated.',
-    );
-    return normalizePathSeparatorsToSystem(symlinkTarget);
   }
 
   #getFileData(

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -748,13 +748,13 @@ export default class TreeFS implements MutableFileSystem {
         // with the remaining path results in collapsing segments, e.g:
         // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
         // parentofroot and root as ancestors.
-        ancestorOfRootIdx =
-          this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget);
         if (
           collectAncestors &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
-          (ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0)
+          ((ancestorOfRootIdx =
+            this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget)) === 0 ||
+            joinedResult.collapsedSegments > 0)
         ) {
           let node: MixedNode = this.#rootNode;
           let collapsedPath = '';

--- a/packages/metro-file-map/src/lib/TreeFS.js
+++ b/packages/metro-file-map/src/lib/TreeFS.js
@@ -21,6 +21,7 @@ import type {
 } from '../flow-types';
 
 import H from '../constants';
+import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
 import {RootPathUtils} from './RootPathUtils';
 import invariant from 'invariant';
 import path from 'node:path';
@@ -1222,11 +1223,12 @@ export default class TreeFS implements MutableFileSystem {
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path,
   ): NormalizedSymlinkTarget {
-    const symlinkTarget = symlinkNode[H.SYMLINK];
+    let symlinkTarget = symlinkNode[H.SYMLINK];
     invariant(
       typeof symlinkTarget === 'string',
       'Expected symlink target to be populated.',
     );
+    symlinkTarget = normalizePathSeparatorsToSystem(symlinkTarget);
     const result = {
       ancestorOfRootIdx: this.#pathUtils.getAncestorOfRootIdx(symlinkTarget),
       normalPath: symlinkTarget,

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -153,4 +153,45 @@ describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
   ])('getAncestorOfRootIdx (%s => %s)', (input, expected) => {
     expect(pathUtils.getAncestorOfRootIdx(input)).toEqual(expected);
   });
+
+  describe('resolveSymlinkToNormal', () => {
+    beforeEach(() => {
+      pathUtils = new RootPathUtils(p('/project/root'));
+    });
+
+    test.each([
+      ['foo/link', './target.js', p('foo/target.js')],
+      ['foo/link', '../bar.js', 'bar.js'],
+      ['link', 'target.js', 'target.js'],
+      [p('a/b/link'), p('../../c.js'), 'c.js'],
+      [p('a/b/link'), p('../../../outside/f.js'), p('../outside/f.js')],
+    ])(
+      'resolves relative target (%s -> %s) to %s',
+      (symlinkPath, readlinkResult, expected) => {
+        expect(
+          pathUtils.resolveSymlinkToNormal(p(symlinkPath), readlinkResult),
+        ).toEqual(expected);
+      },
+    );
+
+    test.each([
+      ['link', p('/project/root/target.js'), 'target.js'],
+      ['link', p('/project/root/a/b.js'), p('a/b.js')],
+      ['link', p('/outside/foo.js'), p('../../outside/foo.js')],
+      [p('a/link'), p('/project/root'), ''],
+    ])(
+      'resolves absolute target (%s -> %s) to %s',
+      (symlinkPath, readlinkResult, expected) => {
+        expect(
+          pathUtils.resolveSymlinkToNormal(p(symlinkPath), readlinkResult),
+        ).toEqual(expected);
+      },
+    );
+
+    test('strips trailing separator from target', () => {
+      expect(
+        pathUtils.resolveSymlinkToNormal('link', p('/project/root/dir/')),
+      ).toEqual('dir');
+    });
+  });
 });

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -246,4 +246,45 @@ describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
       );
     });
   }
+
+  describe('resolveSymlinkToNormal', () => {
+    beforeEach(() => {
+      pathUtils = new RootPathUtils(p('/project/root'));
+    });
+
+    test.each([
+      ['foo/link', './target.js', p('foo/target.js')],
+      ['foo/link', '../bar.js', 'bar.js'],
+      ['link', 'target.js', 'target.js'],
+      [p('a/b/link'), p('../../c.js'), 'c.js'],
+      [p('a/b/link'), p('../../../outside/f.js'), p('../outside/f.js')],
+    ])(
+      'resolves relative target (%s -> %s) to %s',
+      (symlinkPath, readlinkResult, expected) => {
+        expect(
+          pathUtils.resolveSymlinkToNormal(p(symlinkPath), readlinkResult),
+        ).toEqual(expected);
+      },
+    );
+
+    test.each([
+      ['link', p('/project/root/target.js'), 'target.js'],
+      ['link', p('/project/root/a/b.js'), p('a/b.js')],
+      ['link', p('/outside/foo.js'), p('../../outside/foo.js')],
+      [p('a/link'), p('/project/root'), ''],
+    ])(
+      'resolves absolute target (%s -> %s) to %s',
+      (symlinkPath, readlinkResult, expected) => {
+        expect(
+          pathUtils.resolveSymlinkToNormal(p(symlinkPath), readlinkResult),
+        ).toEqual(expected);
+      },
+    );
+
+    test('strips trailing separator from target', () => {
+      expect(
+        pathUtils.resolveSymlinkToNormal('link', p('/project/root/dir/')),
+      ).toEqual('dir');
+    });
+  });
 });

--- a/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/RootPathUtils-test.js
@@ -286,5 +286,33 @@ describe.each([['win32'], ['posix']])('RootPathUtils on %s', platform => {
         pathUtils.resolveSymlinkToNormal('link', p('/project/root/dir/')),
       ).toEqual('dir');
     });
+
+    // A filesystem root is the one absolute target that consists only of a
+    // separator, so it must not be trimmed before we test for absoluteness.
+    test.each([
+      ['link', p('/'), p('../..')],
+      [p('a/link'), p('/'), p('../..')],
+    ])(
+      'resolves filesystem root target (%s -> %s) to %s',
+      (symlinkPath, readlinkResult, expected) => {
+        expect(
+          pathUtils.resolveSymlinkToNormal(symlinkPath, readlinkResult),
+        ).toEqual(expected);
+      },
+    );
+
+    if (platform === 'win32') {
+      test.each([
+        ['D:\\', '..\\..\\..\\D:'],
+        ['D:\\ext\\', '..\\..\\..\\D:\\ext'],
+      ])(
+        'resolves cross-drive root target (%s) to %s',
+        (readlinkResult, expected) => {
+          expect(
+            pathUtils.resolveSymlinkToNormal('link', readlinkResult),
+          ).toEqual(expected);
+        },
+      );
+    }
   });
 });

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -41,18 +41,18 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       rootDir: p('/project'),
       files: new Map<CanonicalPath, FileMetadata>([
         [p('foo/another.js'), [123, 2, 0, null, 0, 'another']],
-        [p('foo/owndir'), [0, 0, 0, null, '.', null]],
-        [p('foo/link-to-bar.js'), [0, 0, 0, null, p('../bar.js'), null]],
-        [p('foo/link-to-another.js'), [0, 0, 0, null, p('another.js'), null]],
+        [p('foo/owndir'), [0, 0, 0, null, 'foo', null]],
+        [p('foo/link-to-bar.js'), [0, 0, 0, null, 'bar.js', null]],
+        [p('foo/link-to-another.js'), [0, 0, 0, null, 'foo/another.js', null]],
         [p('../outside/external.js'), [0, 0, 0, null, 0, null]],
         [p('bar.js'), [234, 3, 0, null, 0, 'bar']],
-        [p('link-to-foo'), [456, 0, 0, null, p('./../project/foo'), null]],
-        [p('abs-link-out'), [456, 0, 0, null, p('/outside/./baz/..'), null]],
+        [p('link-to-foo'), [456, 0, 0, null, 'foo', null]],
+        [p('abs-link-out'), [456, 0, 0, null, '../outside', null]],
         [p('root'), [0, 0, 0, null, '..', null]],
-        [p('link-to-nowhere'), [123, 0, 0, null, p('./nowhere'), null]],
-        [p('link-to-self'), [123, 0, 0, null, p('./link-to-self'), null]],
-        [p('link-cycle-1'), [123, 0, 0, null, p('./link-cycle-2'), null]],
-        [p('link-cycle-2'), [123, 0, 0, null, p('./link-cycle-1'), null]],
+        [p('link-to-nowhere'), [123, 0, 0, null, 'nowhere', null]],
+        [p('link-to-self'), [123, 0, 0, null, 'link-to-self', null]],
+        [p('link-cycle-1'), [123, 0, 0, null, 'link-cycle-2', null]],
+        [p('link-cycle-2'), [123, 0, 0, null, 'link-cycle-1', null]],
         [p('node_modules/pkg/a.js'), [123, 0, 0, null, 0, 'a']],
         [p('node_modules/pkg/package.json'), [123, 0, 0, null, 0, 'pkg']],
       ]),
@@ -194,7 +194,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         rootDir: p('/deep/project/root'),
         files: new Map<CanonicalPath, FileMetadata>([
           [p('foo/index.js'), [123, 0, 0, null, 0, null]],
-          [p('link-up'), [123, 0, 0, null, p('..'), null]],
+          [p('link-up'), [123, 0, 0, null, '..', null]],
         ]),
         processFile: () => {
           throw new Error('Not implemented');
@@ -221,7 +221,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
 
   describe('symlinks to an ancestor of the project root', () => {
     beforeEach(() => {
-      tfs.addOrModify(p('foo/link-up-2'), [0, 0, 0, null, p('../..'), null]);
+      tfs.addOrModify(p('foo/link-up-2'), [0, 0, 0, null, '..', null]);
     });
 
     test.each([
@@ -277,14 +277,14 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
     test('returns changed (inc. new) and removed files in given FileData', () => {
       const newFiles: FileData = new Map<CanonicalPath, FileMetadata>([
         [p('new-file'), [789, 0, 0, null, 0, null]],
-        [p('link-to-foo'), [456, 0, 0, null, p('./foo'), null]],
+        [p('link-to-foo'), [456, 0, 0, null, 'foo', null]],
         // Different modified time, expect new mtime in changedFiles
         [p('foo/another.js'), [124, 0, 0, null, 0, null]],
-        [p('link-cycle-1'), [123, 0, 0, null, p('./link-cycle-2'), null]],
-        [p('link-cycle-2'), [123, 0, 0, null, p('./link-cycle-1'), null]],
+        [p('link-cycle-1'), [123, 0, 0, null, 'link-cycle-2', null]],
+        [p('link-cycle-2'), [123, 0, 0, null, 'link-cycle-1', null]],
         // Was a symlink, now a regular file
         [p('link-to-self'), [123, 0, 0, null, 0, null]],
-        [p('link-to-nowhere'), [123, 0, 0, null, p('./nowhere'), null]],
+        [p('link-to-nowhere'), [123, 0, 0, null, 'nowhere', null]],
         [p('node_modules/pkg/a.js'), [123, 0, 0, null, 0, 'a']],
         [p('node_modules/pkg/package.json'), [123, 0, 0, null, 0, 'pkg']],
       ]);
@@ -393,24 +393,18 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
             [
               [
                 p('a/1/package.json'),
-                [0, 0, 0, null, './real-package.json', null],
+                [0, 0, 0, null, 'a/1/real-package.json', null],
               ],
               [
                 p('a/2/package.json'),
-                [0, 0, 0, null, './notexist-package.json', null],
+                [0, 0, 0, null, 'a/2/notexist-package.json', null],
               ],
-              [p('a/b/c/d/link-to-C'), [0, 0, 0, null, p('../../../..'), null]],
-              [
-                p('a/b/c/d/link-to-B'),
-                [0, 0, 0, null, p('../../../../..'), null],
-              ],
-              [
-                p('a/b/c/d/link-to-A'),
-                [0, 0, 0, null, p('../../../../../..'), null],
-              ],
+              [p('a/b/c/d/link-to-C'), [0, 0, 0, null, '', null]],
+              [p('a/b/c/d/link-to-B'), [0, 0, 0, null, '..', null]],
+              [p('a/b/c/d/link-to-A'), [0, 0, 0, null, '../..', null]],
               [
                 p('n_m/workspace/link-to-pkg'),
-                [0, 0, 0, null, p('../../../workspace-pkg'), null],
+                [0, 0, 0, null, '../workspace-pkg', null],
               ],
             ] as Array<[CanonicalPath, FileMetadata]>
           ).concat(
@@ -817,7 +811,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           new Map<CanonicalPath, FileMetadata>([
             [
               p('newdir/link-to-link-to-bar.js'),
-              [0, 0, 0, null, p('../foo/link-to-bar.js'), null],
+              [0, 0, 0, null, 'foo/link-to-bar.js', null],
             ],
             [p('foo/baz.js'), [0, 0, 0, null, 0, null]],
             [p('bar.js'), [999, 1, 0, null, 0, null]],
@@ -967,7 +961,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           {
             baseName: 'link-to-bar.js',
             canonicalPath: p('foo/link-to-bar.js'),
-            metadata: [0, 0, 0, null, p('../bar.js'), null],
+            metadata: [0, 0, 0, null, 'bar.js', null],
           },
         ]),
       );
@@ -983,7 +977,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         files: new Map<CanonicalPath, FileMetadata>([
           [p('foo.js'), [123, 0, 0, 'def456', 0, null]],
           [p('bar.js'), [123, 0, 0, null, 0, null]],
-          [p('link-to-bar'), [456, 0, 0, null, p('./bar.js'), null]],
+          [p('link-to-bar'), [456, 0, 0, null, 'bar.js', null]],
         ]),
         processFile: mockProcessFile,
       });
@@ -1084,7 +1078,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         files: new Map<CanonicalPath, FileMetadata>([
           [p('existing.js'), [123, 0, 0, '', 0]],
           [p('dir/nested.js'), [456, 0, 0, '', 0]],
-          [p('mylink'), [0, 0, 0, '', p('./dir')]],
+          [p('mylink'), [0, 0, 0, '', 'dir']],
         ]),
         processFile: () => {
           throw new Error('Not implemented');
@@ -1214,23 +1208,19 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       test('tracks added files when adding a symlink', () => {
         simpleTfs.addOrModify(
           p('link-to-existing'),
-          [0, 0, 0, '', p('./existing.js')],
+          [0, 0, 0, '', 'existing.js'],
           listener,
         );
 
         expect(logChange.mock.calls).toEqual([
-          [
-            'fileAdded',
-            p('link-to-existing'),
-            [0, 0, 0, '', p('./existing.js')],
-          ],
+          ['fileAdded', p('link-to-existing'), [0, 0, 0, '', 'existing.js']],
         ]);
       });
 
       test('tracks removed symlinks with their metadata', () => {
         simpleTfs.remove(p('mylink'), listener);
         expect(logChange.mock.calls).toEqual([
-          ['fileRemoved', p('mylink'), [0, 0, 0, '', p('./dir')]],
+          ['fileRemoved', p('mylink'), [0, 0, 0, '', 'dir']],
         ]);
       });
     });

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -43,11 +43,14 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         [p('foo/another.js'), [123, 2, 0, null, 0, 'another']],
         [p('foo/owndir'), [0, 0, 0, null, 'foo', null]],
         [p('foo/link-to-bar.js'), [0, 0, 0, null, 'bar.js', null]],
-        [p('foo/link-to-another.js'), [0, 0, 0, null, 'foo/another.js', null]],
+        [
+          p('foo/link-to-another.js'),
+          [0, 0, 0, null, p('foo/another.js'), null],
+        ],
         [p('../outside/external.js'), [0, 0, 0, null, 0, null]],
         [p('bar.js'), [234, 3, 0, null, 0, 'bar']],
         [p('link-to-foo'), [456, 0, 0, null, 'foo', null]],
-        [p('abs-link-out'), [456, 0, 0, null, '../outside', null]],
+        [p('abs-link-out'), [456, 0, 0, null, p('../outside'), null]],
         [p('root'), [0, 0, 0, null, '..', null]],
         [p('link-to-nowhere'), [123, 0, 0, null, 'nowhere', null]],
         [p('link-to-self'), [123, 0, 0, null, 'link-to-self', null]],
@@ -411,18 +414,18 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
             [
               [
                 p('a/1/package.json'),
-                [0, 0, 0, null, 'a/1/real-package.json', null],
+                [0, 0, 0, null, p('a/1/real-package.json'), null],
               ],
               [
                 p('a/2/package.json'),
-                [0, 0, 0, null, 'a/2/notexist-package.json', null],
+                [0, 0, 0, null, p('a/2/notexist-package.json'), null],
               ],
               [p('a/b/c/d/link-to-C'), [0, 0, 0, null, '', null]],
               [p('a/b/c/d/link-to-B'), [0, 0, 0, null, '..', null]],
-              [p('a/b/c/d/link-to-A'), [0, 0, 0, null, '../..', null]],
+              [p('a/b/c/d/link-to-A'), [0, 0, 0, null, p('../..'), null]],
               [
                 p('n_m/workspace/link-to-pkg'),
-                [0, 0, 0, null, '../workspace-pkg', null],
+                [0, 0, 0, null, p('../workspace-pkg'), null],
               ],
             ] as Array<[CanonicalPath, FileMetadata]>
           ).concat(
@@ -829,7 +832,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           new Map<CanonicalPath, FileMetadata>([
             [
               p('newdir/link-to-link-to-bar.js'),
-              [0, 0, 0, null, 'foo/link-to-bar.js', null],
+              [0, 0, 0, null, p('foo/link-to-bar.js'), null],
             ],
             [p('foo/baz.js'), [0, 0, 0, null, 0, null]],
             [p('bar.js'), [999, 1, 0, null, 0, null]],
@@ -1310,7 +1313,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           rootDir: 'C:\\project',
           files: new Map<CanonicalPath, FileMetadata>([
             ['..\\..\\D:\\external\\file.js', externalMeta],
-            ['link', [0, 0, 0, null, '../../D:/external/file.js', null]],
+            ['link', [0, 0, 0, null, '..\\..\\D:\\external\\file.js', null]],
           ]),
           processFile: () => {
             throw new Error('Not implemented');

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -253,6 +253,24 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       },
     );
 
+    test('a link to the filesystem root behaves like a link to ..', () => {
+      const {RootPathUtils} = require('../RootPathUtils');
+      // The project root is one level below the filesystem root here, so a
+      // symlink to the filesystem root must resolve to '..', not to ''.
+      const stored = new RootPathUtils(p('/project')).resolveSymlinkToNormal(
+        p('foo/link-to-fs-root'),
+        p('/'),
+      );
+      expect(stored).toEqual('..');
+      tfs.addOrModify(p('foo/link-to-fs-root'), [0, 0, 0, null, stored, null]);
+      expect(tfs.lookup(p('foo/link-to-fs-root/project/bar.js'))).toMatchObject(
+        {
+          exists: true,
+          realPath: p('/project/bar.js'),
+        },
+      );
+    });
+
     test('matchFiles follows links up', () => {
       const matches = [
         ...tfs.matchFiles({

--- a/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
+++ b/packages/metro-file-map/src/lib/__tests__/TreeFS-test.js
@@ -41,18 +41,18 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       rootDir: p('/project'),
       files: new Map<CanonicalPath, FileMetadata>([
         [p('foo/another.js'), [123, 2, 0, null, 0, 'another']],
-        [p('foo/owndir'), [0, 0, 0, null, '.', null]],
-        [p('foo/link-to-bar.js'), [0, 0, 0, null, p('../bar.js'), null]],
-        [p('foo/link-to-another.js'), [0, 0, 0, null, p('another.js'), null]],
+        [p('foo/owndir'), [0, 0, 0, null, 'foo', null]],
+        [p('foo/link-to-bar.js'), [0, 0, 0, null, 'bar.js', null]],
+        [p('foo/link-to-another.js'), [0, 0, 0, null, 'foo/another.js', null]],
         [p('../outside/external.js'), [0, 0, 0, null, 0, null]],
         [p('bar.js'), [234, 3, 0, null, 0, 'bar']],
-        [p('link-to-foo'), [456, 0, 0, null, p('./../project/foo'), null]],
-        [p('abs-link-out'), [456, 0, 0, null, p('/outside/./baz/..'), null]],
+        [p('link-to-foo'), [456, 0, 0, null, 'foo', null]],
+        [p('abs-link-out'), [456, 0, 0, null, '../outside', null]],
         [p('root'), [0, 0, 0, null, '..', null]],
-        [p('link-to-nowhere'), [123, 0, 0, null, p('./nowhere'), null]],
-        [p('link-to-self'), [123, 0, 0, null, p('./link-to-self'), null]],
-        [p('link-cycle-1'), [123, 0, 0, null, p('./link-cycle-2'), null]],
-        [p('link-cycle-2'), [123, 0, 0, null, p('./link-cycle-1'), null]],
+        [p('link-to-nowhere'), [123, 0, 0, null, 'nowhere', null]],
+        [p('link-to-self'), [123, 0, 0, null, 'link-to-self', null]],
+        [p('link-cycle-1'), [123, 0, 0, null, 'link-cycle-2', null]],
+        [p('link-cycle-2'), [123, 0, 0, null, 'link-cycle-1', null]],
         [p('node_modules/pkg/a.js'), [123, 0, 0, null, 0, 'a']],
         [p('node_modules/pkg/package.json'), [123, 0, 0, null, 0, 'pkg']],
       ]),
@@ -194,7 +194,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         rootDir: p('/deep/project/root'),
         files: new Map<CanonicalPath, FileMetadata>([
           [p('foo/index.js'), [123, 0, 0, null, 0, null]],
-          [p('link-up'), [123, 0, 0, null, p('..'), null]],
+          [p('link-up'), [123, 0, 0, null, '..', null]],
         ]),
         processFile: () => {
           throw new Error('Not implemented');
@@ -221,7 +221,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
 
   describe('symlinks to an ancestor of the project root', () => {
     beforeEach(() => {
-      tfs.addOrModify(p('foo/link-up-2'), [0, 0, 0, null, p('../..'), null]);
+      tfs.addOrModify(p('foo/link-up-2'), [0, 0, 0, null, '..', null]);
     });
 
     test.each([
@@ -277,14 +277,14 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
     test('returns changed (inc. new) and removed files in given FileData', () => {
       const newFiles: FileData = new Map<CanonicalPath, FileMetadata>([
         [p('new-file'), [789, 0, 0, null, 0, null]],
-        [p('link-to-foo'), [456, 0, 0, null, p('./foo'), null]],
+        [p('link-to-foo'), [456, 0, 0, null, 'foo', null]],
         // Different modified time, expect new mtime in changedFiles
         [p('foo/another.js'), [124, 0, 0, null, 0, null]],
-        [p('link-cycle-1'), [123, 0, 0, null, p('./link-cycle-2'), null]],
-        [p('link-cycle-2'), [123, 0, 0, null, p('./link-cycle-1'), null]],
+        [p('link-cycle-1'), [123, 0, 0, null, 'link-cycle-2', null]],
+        [p('link-cycle-2'), [123, 0, 0, null, 'link-cycle-1', null]],
         // Was a symlink, now a regular file
         [p('link-to-self'), [123, 0, 0, null, 0, null]],
-        [p('link-to-nowhere'), [123, 0, 0, null, p('./nowhere'), null]],
+        [p('link-to-nowhere'), [123, 0, 0, null, 'nowhere', null]],
         [p('node_modules/pkg/a.js'), [123, 0, 0, null, 0, 'a']],
         [p('node_modules/pkg/package.json'), [123, 0, 0, null, 0, 'pkg']],
       ]);
@@ -393,24 +393,18 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
             [
               [
                 p('a/1/package.json'),
-                [0, 0, 0, null, './real-package.json', null],
+                [0, 0, 0, null, 'a/1/real-package.json', null],
               ],
               [
                 p('a/2/package.json'),
-                [0, 0, 0, null, './notexist-package.json', null],
+                [0, 0, 0, null, 'a/2/notexist-package.json', null],
               ],
-              [p('a/b/c/d/link-to-C'), [0, 0, 0, null, p('../../../..'), null]],
-              [
-                p('a/b/c/d/link-to-B'),
-                [0, 0, 0, null, p('../../../../..'), null],
-              ],
-              [
-                p('a/b/c/d/link-to-A'),
-                [0, 0, 0, null, p('../../../../../..'), null],
-              ],
+              [p('a/b/c/d/link-to-C'), [0, 0, 0, null, '', null]],
+              [p('a/b/c/d/link-to-B'), [0, 0, 0, null, '..', null]],
+              [p('a/b/c/d/link-to-A'), [0, 0, 0, null, '../..', null]],
               [
                 p('n_m/workspace/link-to-pkg'),
-                [0, 0, 0, null, p('../../../workspace-pkg'), null],
+                [0, 0, 0, null, '../workspace-pkg', null],
               ],
             ] as Array<[CanonicalPath, FileMetadata]>
           ).concat(
@@ -817,7 +811,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           new Map<CanonicalPath, FileMetadata>([
             [
               p('newdir/link-to-link-to-bar.js'),
-              [0, 0, 0, null, p('../foo/link-to-bar.js'), null],
+              [0, 0, 0, null, 'foo/link-to-bar.js', null],
             ],
             [p('foo/baz.js'), [0, 0, 0, null, 0, null]],
             [p('bar.js'), [999, 1, 0, null, 0, null]],
@@ -967,7 +961,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           {
             baseName: 'link-to-bar.js',
             canonicalPath: p('foo/link-to-bar.js'),
-            metadata: [0, 0, 0, null, p('../bar.js'), null],
+            metadata: [0, 0, 0, null, 'bar.js', null],
           },
         ]),
       );
@@ -983,7 +977,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         files: new Map<CanonicalPath, FileMetadata>([
           [p('foo.js'), [123, 0, 0, 'def456', 0, null]],
           [p('bar.js'), [123, 0, 0, null, 0, null]],
-          [p('link-to-bar'), [456, 0, 0, null, p('./bar.js'), null]],
+          [p('link-to-bar'), [456, 0, 0, null, 'bar.js', null]],
         ]),
         processFile: mockProcessFile,
       });
@@ -1084,7 +1078,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
         files: new Map<CanonicalPath, FileMetadata>([
           [p('existing.js'), [123, 0, 0, '', 0]],
           [p('dir/nested.js'), [456, 0, 0, '', 0]],
-          [p('mylink'), [0, 0, 0, '', p('./dir')]],
+          [p('mylink'), [0, 0, 0, '', 'dir']],
         ]),
         processFile: () => {
           throw new Error('Not implemented');
@@ -1214,23 +1208,19 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
       test('tracks added files when adding a symlink', () => {
         simpleTfs.addOrModify(
           p('link-to-existing'),
-          [0, 0, 0, '', p('./existing.js')],
+          [0, 0, 0, '', 'existing.js'],
           listener,
         );
 
         expect(logChange.mock.calls).toEqual([
-          [
-            'fileAdded',
-            p('link-to-existing'),
-            [0, 0, 0, '', p('./existing.js')],
-          ],
+          ['fileAdded', p('link-to-existing'), [0, 0, 0, '', 'existing.js']],
         ]);
       });
 
       test('tracks removed symlinks with their metadata', () => {
         simpleTfs.remove(p('mylink'), listener);
         expect(logChange.mock.calls).toEqual([
-          ['fileRemoved', p('mylink'), [0, 0, 0, '', p('./dir')]],
+          ['fileRemoved', p('mylink'), [0, 0, 0, '', 'dir']],
         ]);
       });
     });
@@ -1302,7 +1292,7 @@ describe.each([['win32'], ['posix']])('TreeFS on %s', platform => {
           rootDir: 'C:\\project',
           files: new Map<CanonicalPath, FileMetadata>([
             ['..\\..\\D:\\external\\file.js', externalMeta],
-            ['link', [0, 0, 0, null, 'D:\\external\\file.js', null]],
+            ['link', [0, 0, 0, null, '../../D:/external/file.js', null]],
           ]),
           processFile: () => {
             throw new Error('Not implemented');

--- a/packages/metro-file-map/types/lib/RootPathUtils.d.ts
+++ b/packages/metro-file-map/types/lib/RootPathUtils.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<5ecdb559fce5f5c6ed50df6e4eaebf20>>
+ * @generated SignedSource<<de7026bc6d3d1406108afc1b07d26f32>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/lib/RootPathUtils.js
@@ -21,6 +21,10 @@ export declare class RootPathUtils {
   absoluteToNormal(absolutePath: string): string;
   normalToAbsolute(normalPath: string): string;
   relativeToNormal(relativePath: string): string;
+  resolveSymlinkToNormal(
+    symlinkNormalPath: string,
+    readlinkResult: string,
+  ): string;
   getAncestorOfRootIdx(normalPath: string): null | undefined | number;
   joinNormalToRelative(
     normalPath: string,


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is part of the same pick/patch-set from [an experiment on the Expo repo](https://github.com/expo/expo/pull/44567),
> like #1676, #1677, and #1686, for `metro-file-map` (conflicts are expected, since changes were pulled out into separate PRs for clarity)

The symlinks have two oddities to them compared to other file data operations and entries:
- a separate `WeakMap` cache is kept for resolved symlink targets that have been converted
- the values stored for symlink targets may be absolute paths and are unnormalised system paths 

The `WeakMap` (in theory) is inefficient especially for projects with a larger amount of symlinks. It's also not necessary since the values can be trivially pre-resolved to a normal path. We can additionally store this value as a posix normal path, to make sure that it's identical between systems, which may help testing.

Edit: A primitive (LLM-generated) benchmark that shows that performance remains within margins with this change can be found at https://github.com/kitten/metro/commit/eee7a821ae3c17fca994ca035b8f41f2cb15faa1

Changelog: [Internal] Pre-resolve symlinks and store normalized symlink targets in file map

## Test plan

- Unit tests were added to demonstrate the changes
- This can further be tested E2E in [the linked Expo PR](https://github.com/expo/expo/pull/44567), although not in isolation (if necessary I can create a new, isolated branch with a pnpm patch for these changes)