### PR TITLE
fix: replace vulnerable image-size with image-size-next (CVE-2025-71329/71330)

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -34,7 +34,7 @@
     "flow-enums-runtime": "^0.0.6",
     "graceful-fs": "^4.2.4",
     "flow-parser": "0.325.0",
-    "image-size": "^1.0.2",
+    "image-size-next": "2.1.0",
     "invariant": "^2.2.4",
     "jest-worker": "^29.7.0",
     "jsc-safe-url": "^0.2.2",

--- a/packages/metro/src/Assets.js
+++ b/packages/metro/src/Assets.js
@@ -13,8 +13,8 @@ import type {AssetPath} from './node-haste/lib/AssetPaths';
 
 import {normalizePathSeparatorsToPosix} from './lib/pathUtils';
 import * as AssetPaths from './node-haste/lib/AssetPaths';
-// $FlowFixMe[untyped-import] image-size
-import getImageSize from 'image-size';
+// $FlowFixMe[untyped-import] image-size-next (maintained drop-in for image-size)
+import getImageSize from 'image-size-next';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -51,7 +51,7 @@ export type AssetDataFiltered = {
   ...
 };
 
-// Test extension against all types supported by image-size module.
+// Test extension against all types supported by image-size / image-size-next module.
 // If it's not one of these, we won't treat it as an image.
 export function isAssetTypeAnImage(type: string): boolean {
   return (

--- a/packages/metro/src/__tests__/Assets-test.js
+++ b/packages/metro/src/__tests__/Assets-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 jest.mock('node:fs', () => new (require('metro-memory-fs'))());
-jest.mock('image-size');
+jest.mock('image-size-next');
 
 jest.useRealTimers();
 
@@ -24,7 +24,7 @@ const fs = jest.requireMock('node:fs');
 const mockImageWidth = 300;
 const mockImageHeight = 200;
 
-require('image-size').mockReturnValue({
+require('image-size-next').mockReturnValue({
   width: mockImageWidth,
   height: mockImageHeight,
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3517,12 +3517,11 @@ ignore@^7.0.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-image-size@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
-  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
-  dependencies:
-    queue "6.0.2"
+image-size-next@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/image-size-next/-/image-size-next-2.1.0.tgz#f0c2d5ea995f6beb974b17c02265d924647a360f"
+  integrity sha512-OUXyc22p+zA9CmiJbuYygTcoHbmZ9tFnJ0NX8LcgfewtrKJnfM+zYwsfrNdoKqz9WsSPTR++2yz+Fqz7Rzvvjg==
+
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
## Summary

Metro depends on **`image-size@^1.0.2`**, used in `Assets.js` to read image dimensions. Upstream **`image-size` is archived** and remains affected by:

- **CVE-2025-71329** — DoS infinite loop (JXL/HEIF/JP2 zero-size boxes)
- **CVE-2025-71330** — DoS infinite loop (ICNS zero entry length)

This PR switches the direct dependency and source/tests to the community MIT drop-in **`image-size-next@2.1.0`**, which keeps the same public API (`default` / `imageSize` export used as `getImageSize(buffer)`).

| | |
|--|--|
| npm | https://www.npmjs.com/package/image-size-next |
| GitHub | https://github.com/lcf2212dev/image-size-next |
| Related RN resolution PR | https://github.com/react/react-native/pull/57894 |

Not affiliated with the original `image-size` maintainer.

### Code changes

- `packages/metro/package.json` — `image-size` → `image-size-next@2.1.0`
- `packages/metro/src/Assets.js` — import from `image-size-next`
- `packages/metro/src/__tests__/Assets-test.js` — jest mock path
- `yarn.lock` — lock entry for `image-size-next@2.1.0`

## Test plan

- [ ] `yarn` install in monorepo
- [ ] Run Metro asset tests: package `metro` / `Assets-test.js`
- [ ] Smoke: resolve dimensions for png/jpg asset via `getAssetSize`
- [ ] Confirm no remaining `require('image-size')` / `from 'image-size'` in `packages/metro`

## Note

A monorepo-level Yarn resolution was also proposed on React Native (#57894) as a temporary shield for nested installs. Landing the dependency change **here** is the durable fix for all Metro consumers.