### PR TITLE
fix: resolve image-size to image-size-next@1.2.2 (CVE-2025-71329/71330)

### DIFF
--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -34,7 +34,7 @@
     "flow-enums-runtime": "^0.0.6",
     "graceful-fs": "^4.2.4",
     "flow-parser": "0.327.0",
-    "image-size": "^1.0.2",
+    "image-size": "npm:image-size-next@1.2.2",
     "invariant": "^2.2.4",
     "jest-worker": "^29.7.0",
     "jsc-safe-url": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3497,10 +3497,10 @@ ignore@^7.0.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-image-size@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
-  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+"image-size@npm:image-size-next@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/image-size-next/-/image-size-next-1.2.2.tgz#40997f20d5918fed93717c7cb1acc58b7e15d361"
+  integrity sha512-Pd3CJ2+Ifk2H2jWikkoz2BSZgnuF3Qsea4gQmj2gtiOtYpGWBl7elj8EXnFMiY5PaYNruTTLD0hQ0UWK7pz9xA==
   dependencies:
     queue "6.0.2"
 


### PR DESCRIPTION
## Summary

Please treat this pull request with care and review the modified files directly. The change is small and **not a critical / API change**: Metro still imports `image-size` and still uses the same 1.x default-export API (`getImageSize(buffer)`).

I work at **CAIXA Econômica Federal**, a large Brazilian state-owned bank, with more than **84,000 employees** and more than **150,000 clients**. Our new banking app is still in **beta** and is already released to **100,000 clients**.

The architecture is React Native with **rspack**. A host app manages **hundreds of federated mini-apps**. Clearing **[CVE-2025-71329](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq)** and **[CVE-2025-71330](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr)** is part of our CI/CD process. The security criteria for this bank project are extremely strict — scanners block the pipeline while `image-size@1.0.2` remains the resolved dependency.

**`image-size-next@1.2.2` was built exclusively for Metro.** Metro depends on `image-size@^1.0.2` (the 1.x default-export API). The 2.x line is a different surface and is **not** what this PR installs. `1.2.2` is published on npm with the `legacy` dist-tag so it does **not** become `latest` (`latest` remains `2.1.1`).

This replaces closed PR #1853, which incorrectly targeted `image-size-next@2.1.0` and rewired imports. That was the wrong major for Metro.

| | |
| --- | --- |
| This PR | `packages/metro/package.json` + `yarn.lock` only |
| Specifier | `"image-size": "npm:image-size-next@1.2.2"` |
| Source / tests | **unchanged** (`import` / `jest.mock('image-size')`) |
| npm `1.2.2` | https://www.npmjs.com/package/image-size-next/v/1.2.2 |
| Diff vs upstream `v1.2.1` | https://github.com/lcf2212dev/image-size-next/compare/v1.2.1...v1.2.2 |

Please look at that compare. The delta is the DoS bounds checks (zero-size JXL/HEIF/JP2 boxes; zero-length ICNS entries) on the same 1.x tree Metro already consumes.

Not affiliated with the original `image-size` author.

**Note on upstream status:** the GitHub repo for `image-size` was archived because the project moved to Codeberg; the npm package itself is not deprecated. This PR is not claiming otherwise. The remaining problem for us is that **1.0.2 as resolved by Metro is still flagged** for those two CVEs, and that fails a regulated bank CI/CD gate.

CLA is already signed for `lcf2212dev`.

Changelog: [Fix] Resolve image-size to image-size-next@1.2.2 (CVE-2025-71329 / CVE-2025-71330)

## Test plan

- Confirmed `image-size-next@1.2.2` keeps the 1.x CJS shape Metro uses (`module.exports = imageSize`, plus `exports.default`).
- `Assets.js` and `Assets-test.js` still import / mock `'image-size'` — no source change.
- Yarn classic lockfile entry: `image-size@npm:image-size-next@1.2.2` → `1.2.2` (`queue@6.0.2` already present).
- Recommend CI: workspace install + `packages/metro` Assets tests + a smoke that `getAssetSize` still reads png/jpg dimensions.
- Confirm no remaining `image-size@^1.0.2` in the root `yarn.lock`.