### PR TITLE
Ignore file watcher change events that omit a changes payload

### DIFF
--- a/packages/metro/src/DeltaBundler/DeltaCalculator.js
+++ b/packages/metro/src/DeltaBundler/DeltaCalculator.js
@@ -199,7 +199,11 @@ export default class DeltaCalculator<T> extends EventEmitter {
     return false;
   }
 
-  _handleMultipleFileChanges = (changeEvent: ChangeEvent) => {
+  _handleMultipleFileChanges = (changeEvent: ?ChangeEvent) => {
+    // Some third party watchers emit a bare 'change' with no payload.
+    if (changeEvent == null || changeEvent.changes == null) {
+      return;
+    }
     const {changes, logger, rootDir} = changeEvent;
 
     // Process added files: deleted+added = modified, otherwise added

--- a/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/DeltaCalculator-test.js
@@ -420,6 +420,27 @@ describe.each(['posix', 'win32'])('DeltaCalculator (%s)', osPlatform => {
     });
   });
 
+  test('should ignore change events that omit the changes payload', async () => {
+    await deltaCalculator.getDelta({reset: false, shallow: false});
+
+    expect(() => {
+      fileWatcher.emit('change');
+      fileWatcher.emit('change', {});
+    }).not.toThrow();
+
+    const result = await deltaCalculator.getDelta({
+      reset: false,
+      shallow: false,
+    });
+
+    expect(result).toEqual({
+      added: new Map(),
+      modified: new Map(),
+      deleted: new Set(),
+      reset: false,
+    });
+  });
+
   test('should emit an event when there is a relevant file change', done => {
     deltaCalculator
       .getDelta({reset: false, shallow: false})

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -151,7 +151,11 @@ export default class DependencyGraph extends EventEmitter {
     await this._initializedPromise;
   }
 
-  _onHasteChange({changes, rootDir}: ChangeEvent) {
+  _onHasteChange(changeEvent: ?ChangeEvent) {
+    if (changeEvent == null || changeEvent.changes == null) {
+      return;
+    }
+    const {changes, rootDir} = changeEvent;
     this._resolutionCache = new Map();
     [
       ...changes.addedFiles,


### PR DESCRIPTION
Fixes react/metro#1767

Some third party watchers emit a bare change event with no ChangeEvent payload. DeltaCalculator and DependencyGraph then read changes.addedFiles and throw.

These handlers now return early when the payload is missing, so a bad event does not crash the bundler.

DeltaCalculator tests cover a change emit with no argument and with an empty object.

Changelog: [Fix] Ignore file watcher change events that omit a changes payload