### PR TITLE
[0.83] Update facebook/metro -> react/metro for trusted publish

### DIFF
--- a/packages/buck-worker-tool/package.json
+++ b/packages/buck-worker-tool/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/buck-worker-tool"
   },
   "main": "src/worker-tool.js",

--- a/packages/metro-babel-register/package.json
+++ b/packages/metro-babel-register/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-babel-register"
   },
   "dependencies": {

--- a/packages/metro-babel-transformer/package.json
+++ b/packages/metro-babel-transformer/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-babel-transformer"
   },
   "scripts": {

--- a/packages/metro-cache-key/package.json
+++ b/packages/metro-cache-key/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-cache-key"
   },
   "scripts": {

--- a/packages/metro-cache/package.json
+++ b/packages/metro-cache/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-cache"
   },
   "scripts": {

--- a/packages/metro-config/package.json
+++ b/packages/metro-config/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-config"
   },
   "scripts": {

--- a/packages/metro-core/package.json
+++ b/packages/metro-core/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-core"
   },
   "scripts": {

--- a/packages/metro-file-map/package.json
+++ b/packages/metro-file-map/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-file-map"
   },
   "scripts": {

--- a/packages/metro-minify-terser/package.json
+++ b/packages/metro-minify-terser/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-minify-terser"
   },
   "scripts": {

--- a/packages/metro-resolver/package.json
+++ b/packages/metro-resolver/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-resolver"
   },
   "scripts": {

--- a/packages/metro-runtime/package.json
+++ b/packages/metro-runtime/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-runtime"
   },
   "scripts": {

--- a/packages/metro-source-map/package.json
+++ b/packages/metro-source-map/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-source-map"
   },
   "scripts": {

--- a/packages/metro-symbolicate/package.json
+++ b/packages/metro-symbolicate/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-symbolicate"
   },
   "scripts": {

--- a/packages/metro-transform-plugins/package.json
+++ b/packages/metro-transform-plugins/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-transform-plugins"
   },
   "scripts": {

--- a/packages/metro-transform-worker/package.json
+++ b/packages/metro-transform-worker/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro-transform-worker"
   },
   "scripts": {

--- a/packages/metro/package.json
+++ b/packages/metro/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/metro"
   },
   "scripts": {

--- a/packages/ob1/package.json
+++ b/packages/ob1/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/facebook/metro.git",
+    "url": "git+https://github.com/react/metro.git",
     "directory": "packages/ob1"
   },
   "scripts": {

--- a/scripts/__tests__/subpackages-test.js
+++ b/scripts/__tests__/subpackages-test.js
@@ -216,7 +216,7 @@ module.exports = require('./${flowFileBaseName}');
     test('has a repository field with correct format', () => {
       expect(packageJson.repository).toEqual({
         type: 'git',
-        url: 'git+https://github.com/facebook/metro.git',
+        url: 'git+https://github.com/react/metro.git',
         directory: packagePath.split(path.sep).filter(Boolean).join('/'),
       });
     });


### PR DESCRIPTION
Picks https://github.com/react/metro/commit/bba9734ce6f346e4c3cb367ea342453a16145ac1 to 0.83, required for Trusted Publish provenance check.