### PR TITLE
TypeScript: Restore publishing of underscore-prefixed identifiers in .d.ts

### DIFF
--- a/packages/metro/src/lib/metroSchemeResolver.js
+++ b/packages/metro/src/lib/metroSchemeResolver.js
@@ -38,7 +38,7 @@ function getBabelRuntimePackageJsonPath(): string {
  * Resolver used for Metro's own `metro:` URI scheme, currently handling only
  * metro:babel-runtime and subpaths.
  */
-const metroSchemeResolver: CustomResolver = (context, specifier, platform) => {
+export default ((context, specifier, platform) => {
   const {protocol, pathname} = new URL(specifier);
 
   // Maps `metro:babel-runtime` (and subpaths, e.g.
@@ -61,6 +61,4 @@ const metroSchemeResolver: CustomResolver = (context, specifier, platform) => {
   }
 
   throw new Error(`Unsupported '${protocol}' pathname: ${pathname}`);
-};
-
-export default metroSchemeResolver;
+}) as CustomResolver;

--- a/scripts/generateApiSnapshots.js
+++ b/scripts/generateApiSnapshots.js
@@ -76,7 +76,13 @@ export async function generateApiSnapshots(
   // mode, even when only verifying snapshots) so the extracted API reflects the
   // working tree. This is what lets a private-API change require no committed
   // output while a public-API change surfaces as a snapshot diff.
-  await generateTsDefsForJsGlobs(AUTO_GENERATED_PATTERNS, {verifyOnly: false});
+  await generateTsDefsForJsGlobs(AUTO_GENERATED_PATTERNS, {
+    verifyOnly: false,
+    // Underscore props are private APIs by Flow convention, so we don't want
+    // them in public API.md snapshots as they're not semver guaranteed. We
+    // do include them in .d.ts, as we document private APIs that way.
+    mungeUnderscores: true,
+  });
 
   const errors: Array<{context: string, error: Error}> = [];
   const allSkipped: Array<string> = [];

--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -66,7 +66,8 @@ export async function generateTsDefsForJsGlobs(
   globPattern: string | ReadonlyArray<string>,
   opts: Readonly<{
     verifyOnly: boolean,
-  }> = {verifyOnly: false},
+    mungeUnderscores: boolean,
+  }> = {verifyOnly: false, mungeUnderscores: false},
 ) {
   const linter = new ESLint({
     fix: true,
@@ -219,7 +220,11 @@ export async function generateTsDefsForJsGlobs(
         return;
       }
       try {
-        const flowDef = await translateFlowToFlowDef(source);
+        const flowDef = await translateFlowToFlowDef(
+          source,
+          {},
+          {mungeUnderscores: opts.mungeUnderscores},
+        );
         if (flowDef.includes('declare module.exports')) {
           errors.push({
             sourceFile,


### PR DESCRIPTION

Summary:
`flow-api-translator@0.36.0`, which we first used to publish Metro `0.85.0`, changed the default handling of underscore-prefixed identifiers, filtering them out unless `mungeUnderscores: false` was used explicitly.

eg:
https://unpkg.com/metro@0.84.5/src/Server.d.ts
https://unpkg.com/metro@0.85.0/src/Server.d.ts

This meant they silently disappeared from our published `.d.ts` files, which are intended to describe the entire API (including private props).

Bring them back for `.d.ts` only via `mungeUnderscores: false`. Keep the generated API.md snapshots underscore-free, as underscore-prefixed fields are not part of the semver-guaranteed surface.

Test plan:

```
yarn run build
```

## Before
```
grep _bundler packages/metro/src/Server.d.ts
```

## After
```
grep _bundler packages/metro/types/Server.d.ts
  _bundler: IncrementalBundler;
```

Changelog:
```
 - **[Types]**: Restore publishing of private (underscore-prefixed) fields in TypeScript declarations
```
