### PR TITLE
Ignore Claude worktrees in Flow and Jest

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@ packages/*/build/**
 .hg/**
 .sl/**
 .git/**
+.claude/**
 # this transient dep bundles tests with their package, which flow attempts to parse
 # and crashes out as the test includes purposely malformed json
 **/node_modules/resolve/test/**

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,11 @@
 /** @type {import('jest').Config} **/
 module.exports = {
   filter: '<rootDir>/scripts/jestFilter.js',
-  modulePathIgnorePatterns: ['/node_modules/', 'packages/[^/]+/build/'],
+  modulePathIgnorePatterns: [
+    '/node_modules/',
+    'packages/[^/]+/build/',
+    '<rootDir>/\\.claude/',
+  ],
   snapshotFormat: {
     escapeString: true,
     printBasicPrototype: true,


### PR DESCRIPTION

## Summary

- Ignore `.claude` directories during Flow checks.
- Ignore `.claude` directories during Jest module discovery.
- Prevent nested Claude worktrees from causing duplicate module and test discovery errors.

## Test plan

- `yarn flow`
- `yarn jest --runInBand`

Pass locally even with a nested worktree containing another copy of Metro. They also work inside the worktree (under `.claude`), because exclusions are anchored after the project root.

Changelog: Internal
