### PR TITLE
vscode workspace: Prevent TypeScript checking Flow, enable prettier

### DIFF
--- a/metro.code-workspace
+++ b/metro.code-workspace
@@ -15,6 +15,7 @@
 	"settings": {
 		"editor.formatOnSave": true,
 		"flow.pathToFlow": "${workspaceFolder}/node_modules/.bin/flow",
-		"javascript.validate.enable": false
+		"js/ts.validate.enabled": false,
+		"editor.defaultFormatter": "esbenp.prettier-vscode"
 	}
 }


### PR DESCRIPTION
A couple of tiny quality-of-life improvements for working with Metro outside Meta.

<img width="518" height="96" alt="image" src="https://github.com/user-attachments/assets/80ac1a72-b15a-4d40-a1c1-05a215690aea" />

`formatOnSave` is enabled by default already, but the default formatter wasn't set, so vscode was applying its defaults, which disagree with our prettier config.
