### PR TITLE
Server: Add a charset to Content-Type for text assets and sources

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -586,7 +586,7 @@ export default class Server {
       if (process.env.REACT_NATIVE_ENABLE_ASSET_CACHING === true) {
         res.setHeader('Cache-Control', 'max-age=31536000');
       }
-      res.setHeader('Content-Type', mime.lookup(path.basename(assetPath)));
+      res.setHeader('Content-Type', mime.contentType(path.basename(assetPath)));
       res.end(this._rangeRequestMiddleware(req, res, data, assetPath));
       process.nextTick(() => {
         log(createActionEndEntry(processingAssetRequestLogEntry));
@@ -753,7 +753,7 @@ export default class Server {
       res.end();
       return;
     }
-    const mimeType = mime.lookup(path.basename(relativeFilePathname));
+    const mimeType = mime.contentType(path.basename(relativeFilePathname));
     res.setHeader('Content-Type', mimeType);
     const stream = fs.createReadStream(filePath);
     stream.pipe(res);

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -315,6 +315,7 @@ describe('processRequest', () => {
         load: jest.fn(() => Promise.resolve()),
         getWatcher: jest.fn(() => ({})),
         doesFileExist: jest.fn().mockReturnValue(true),
+        getOrComputeSha1: jest.fn(() => Promise.resolve({sha1: 'abcdef'})),
       }),
     );
 
@@ -950,6 +951,17 @@ describe('processRequest', () => {
       );
     });
 
+    test('should return a charset in the content-type header for a text asset', async () => {
+      const mockData = 'ｉ ａｍ ｈｔｍｌ';
+      getAsset.mockResolvedValue(mockData);
+
+      const response = await makeRequest('/assets/docs/a.html?platform=ios');
+
+      expect(response.getHeader('content-type')).toBe(
+        'text/html; charset=utf-8',
+      );
+    });
+
     test("should serve assets files's name contain non-latin letter", async () => {
       getAsset.mockResolvedValue('i am image');
 
@@ -1010,6 +1022,29 @@ describe('processRequest', () => {
         expect.any(Function),
       );
       expect(response._getString()).toBe('i am image');
+    });
+  });
+
+  describe('source requests', () => {
+    beforeEach(() => {
+      fs.mkdirSync('/root');
+      fs.writeFileSync('/root/foo.js', '// \u3053\u3093\u306b\u3061\u306f\n');
+      fs.writeFileSync('/root/logo.png', 'not really a png');
+    });
+
+    test('serves a source file with a utf-8 charset', async () => {
+      const response = await makeRequest('/[metro-project]/foo.js');
+
+      expect(response.getHeader('content-type')).toBe(
+        'text/javascript; charset=utf-8',
+      );
+      expect(response._getString()).toBe('// \u3053\u3093\u306b\u3061\u306f\n');
+    });
+
+    test('does not add a charset to a binary file', async () => {
+      const response = await makeRequest('/[metro-project]/logo.png');
+
+      expect(response.getHeader('content-type')).toBe('image/png');
     });
   });
 


### PR DESCRIPTION

## Summary

Metro's dev server sets `Content-Type` with `mime.lookup()`, both for `/assets/` and for source files under `/[metro-project]/`. That returns a bare type like `text/html` with no charset, so clients fall back to their own default - #859 is a `WebView` rendering a UTF-8 `.html` asset as mojibake.

`mime-types` has `contentType()` for this. It appends `; charset=utf-8` where a charset applies and is otherwise identical, including returning `false` for an unrecognised extension, so binary assets are unaffected.

Fixes: https://github.com/react/metro/issues/859

Changelog:
```
 - **[Fix]**: Include `charset=utf-8` in the `Content-Type` of text assets and source files served by the dev server
```

## Test plan

```
yarn jest packages/metro/src/Server
yarn flow check
```

New cases for a text asset, a source file and a binary file. The charset assertions fail on `main`.
