### PR TITLE
Inline the last duplicate Platform.select key

### DIFF
--- a/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
@@ -399,6 +399,17 @@ describe('inline constants', () => {
     });
   });
 
+  test('uses the last definition when Platform.select has duplicate keys', () => {
+    const code = `
+      var value = Platform.select({ios: 1, ios: 2});
+    `;
+
+    compare([inlinePlugin], code, 'var value = 2;', {
+      inlinePlatform: true,
+      platform: 'ios',
+    });
+  });
+
   test('inlines Platform.select in the code when using an ObjectMethod', () => {
     const code = `
       function a() {

--- a/packages/metro-transform-plugins/src/inline-plugin.js
+++ b/packages/metro-transform-plugins/src/inline-plugin.js
@@ -90,9 +90,9 @@ export default function inlinePlugin(
     key: string,
     fallback: () => Node,
   ): Node {
-    let value = null;
-
-    for (const p of objectExpression.properties) {
+    // Object literal evaluation keeps the last definition of a duplicate key.
+    for (let i = objectExpression.properties.length - 1; i >= 0; i--) {
+      const p = objectExpression.properties[i];
       if (!isObjectProperty(p) && !isObjectMethod(p)) {
         continue;
       }
@@ -101,16 +101,14 @@ export default function inlinePlugin(
         (isStringLiteral(p.key) && p.key.value === key)
       ) {
         if (isObjectProperty(p)) {
-          value = p.value;
-          break;
+          return p.value;
         } else if (isObjectMethod(p)) {
-          value = t.toExpression(p);
-          break;
+          return t.toExpression(p);
         }
       }
     }
 
-    return value ?? fallback();
+    return fallback();
   }
 
   function hasStaticProperties(objectExpression: ObjectExpression): boolean {


### PR DESCRIPTION
## Summary

Metro statically replaces `Platform.select({...})` for the target platform. Its property scan currently stops at the first matching key, while JavaScript object-literal evaluation keeps the last duplicate definition. For example, `Platform.select({ios: 1, ios: 2})` runs as `2` but Metro compiles it to `1`.

Scan the already-validated static properties from the end and return the first reverse match. This preserves O(n) behavior, avoids an unnecessary nullable temporary, and keeps compiled output consistent with runtime object semantics. The React Native Babel preset contains a parallel transform; companion [React Native PR #58249](https://github.com/facebook/react-native/pull/58249) applies the same rule there.

Changelog:
```
 - **[Fix]**: Inline the last duplicate key from static `Platform.select` object literals
```

## Test plan

- Added a focused `metro-transform-plugins` regression; it fails on pristine main with `1` and passes with `2` after the fix.
- All package suites pass: 6/6 suites, 160/160 tests, 41 snapshots.
- Full Flow check reports no errors.
- Full monorepo build passes for all 17 packages.
- Targeted ESLint, Prettier, and `git diff --check` pass.

No behavior changes for object literals without duplicate static keys.