### PR TITLE
metro-symbolicate: Don't throw on stack frames with no source position

### DIFF
--- a/packages/metro-symbolicate/src/Symbolication.js
+++ b/packages/metro-symbolicate/src/Symbolication.js
@@ -165,7 +165,7 @@ class SymbolicationContext<ModuleIdsT> {
   //  IOS: foo.js:57:foo, Android: bar.js:75:bar
   symbolicate(stackTrace: string): string {
     return stackTrace.replace(
-      /(?:([^@: \n(]+)(@|:))?(?:(?:([^@: \n(]+):)?(\d+):(\d+)|\[native code\])/g,
+      /(?:([^@: \n(]+)(@|:))?(?:(?:([^@: \n(]+):)?(\d+):(\d+)|\[native code\](?::\d+:\d+)?)/g,
       (match, func, delimiter, fileName, line, column) => {
         if (delimiter === ':' && func && !fileName) {
           fileName = func;
@@ -694,10 +694,25 @@ class SingleMapSymbolicationContext extends SymbolicationContext<SingleMapModule
       }
       moduleLineOffset = moduleOffsets[localId];
     }
-    const original = metadata.consumer.originalPositionFor({
-      line: Number(lineNumber) + moduleLineOffset,
-      column: Number(columnNumber),
-    });
+    const line = Number(lineNumber) + moduleLineOffset;
+    const column = Number(columnNumber);
+
+    // Crash reporters normalise frames that have no JS location - native
+    // frames in particular - to line 0, column 0. `originalPositionFor` throws
+    // on an out-of-range position, so report these as unresolved instead,
+    // matching what we already do for a bare `[native code]` frame.
+    if (line <= 0 || column < 0) {
+      return {
+        line: null,
+        column: null,
+        source: null,
+        functionName: null,
+        name: null,
+        isIgnored: false,
+      };
+    }
+
+    const original = metadata.consumer.originalPositionFor({line, column});
     if (metadata.sourceFunctionsConsumer) {
       original.functionName =
         metadata.sourceFunctionsConsumer.functionNameFor(original) || null;

--- a/packages/metro-symbolicate/src/__tests__/__fixtures__/testfile.crashreporter.stack
+++ b/packages/metro-symbolicate/src/__tests__/__fixtures__/testfile.crashreporter.stack
@@ -1,0 +1,6 @@
+Non-fatal Exception: JavaScriptError
+0  ???  0x0 <unknown> (some message with no frame)
+1  ???  0x0 throws6 + 1 (thrower.min.js:1:161)
+2  ???  0x0 o + 1 (thrower.min.js:1:464)
+3  ???  0x0 <unknown> ([native code]:0:0)
+4  ???  0x0 <unknown> ([native code]:0:0)

--- a/packages/metro-symbolicate/src/__tests__/__snapshots__/symbolicate-test.js.snap
+++ b/packages/metro-symbolicate/src/__tests__/__snapshots__/symbolicate-test.js.snap
@@ -216,6 +216,16 @@ Array [
 ]
 `;
 
+exports[`symbolicating a crash reporter stack trace with 0:0 native frames 1`] = `
+"Non-fatal Exception: JavaScriptError
+0  ???  0x0 <unknown> (some message with no frame)
+1  ???  0x0 throws6 + 1 (thrower.js:18:null)
+2  ???  0x0 o + 1 (thrower.js:30:arguments)
+3  ???  0x0 <unknown> (null:null:null)
+4  ???  0x0 <unknown> (null:null:null)
+"
+`;
+
 exports[`symbolicating a profiler map 1`] = `
 "JS_0000_xxxxxxxxxxxxxxxxxxxxxx throws0::thrower.js:48:11
 JS_0001_xxxxxxxxxxxxxxxxxxxxxx throws6::thrower.js:35:38

--- a/packages/metro-symbolicate/src/__tests__/symbolicate-test.js
+++ b/packages/metro-symbolicate/src/__tests__/symbolicate-test.js
@@ -215,6 +215,11 @@ test('symbolicating a stack trace in Node format', async () =>
     execute([TESTFILE_MAP], read('testfile.node.stack')),
   ).resolves.toMatchSnapshot());
 
+test('symbolicating a crash reporter stack trace with 0:0 native frames', async () =>
+  await expect(
+    execute([TESTFILE_MAP], read('testfile.crashreporter.stack')),
+  ).resolves.toMatchSnapshot());
+
 test('symbolicating a single entry', async () =>
   await expect(execute([TESTFILE_MAP, '1', '161'])).resolves.toEqual(
     'thrower.js:18:null\n',


### PR DESCRIPTION

## Summary

`metro-symbolicate` aborts with `TypeError: Line must be greater than or equal to 1, got 0` and emits nothing at all if any frame in the input has line 0. One such frame discards the whole trace, which is why folks in #966 are hand-editing their stack traces first.

Line 0 isn't necessarily malformed input - it's how some crash reporters, Crashlytics for example, represent a frame with no JS source position once every frame has been normalised to `file:line:column`, rendering `[native code]` as `[native code]:0:0`. We already accept the un-normalised form: `symbolicate()`'s regex has an explicit `[native code]` alternative and reports those frames as `null:null:null`.

This makes the normalised form behave the same. `getOriginalPositionDetailsFor` returns an unresolved frame instead of passing a position `source-map` rejects, and the regex consumes a trailing `:0:0` after `[native code]` so the frame matches once rather than twice.

Fixes: https://github.com/react/metro/issues/966
Fixes: https://github.com/react/metro/issues/1021

Changelog:
```
 - **[Fix]**: `metro-symbolicate` no longer fails on stack frames with no source position, such as `[native code]:0:0` in crash reporter output
```

## Test plan

```
yarn jest packages/metro-symbolicate
yarn flow check
```

New snapshot test over a crash-reporter-formatted trace containing `[native code]:0:0` frames, which fails on `main` with the `TypeError`.

