### PR TITLE
Preserve Platform.select initializer side effects

### DIFF
--- a/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
+++ b/packages/metro-transform-plugins/src/__tests__/inline-plugin-test.js
@@ -410,6 +410,20 @@ describe('inline constants', () => {
     });
   });
 
+  test('does not discard impure Platform.select initializers', () => {
+    const code = `
+      var value = Platform.select({
+        ios: selected(),
+        android: discarded(),
+      });
+    `;
+
+    compare([inlinePlugin], code, code, {
+      inlinePlatform: true,
+      platform: 'ios',
+    });
+  });
+
   test('inlines Platform.select in the code when using an ObjectMethod', () => {
     const code = `
       function a() {

--- a/packages/metro-transform-plugins/src/inline-plugin.js
+++ b/packages/metro-transform-plugins/src/inline-plugin.js
@@ -200,8 +200,17 @@ export default function inlinePlugin(
               findProperty(arg, 'native', () =>
                 findProperty(arg, 'default', () => t.identifier('undefined')),
               );
+            const selected = findProperty(arg, opts.platform, fallback);
 
-            path.replaceWith(findProperty(arg, opts.platform, fallback));
+            if (
+              arg.properties.every(
+                property =>
+                  (isObjectProperty(property) && property.value === selected) ||
+                  scope.isPure(property),
+              )
+            ) {
+              path.replaceWith(selected);
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary

Metro replaces `Platform.select({...})` with the selected property during production transforms. JavaScript evaluates every object property initializer before calling `Platform.select`, so this can silently remove side effects from non-selected properties.

For example:

```js
Platform.select({
  ios: selected(),
  android: discarded(),
});
```

JavaScript would run both side effects, `selected()` and `discarded()`. The plugin's current behavior removes `discarded` however.

This fix preserves both side effects by testing for purity.

Changelog:
```
 - **[Fix]**: Preserve side effects from discarded `Platform.select` property initializers
```

## Test plan

Added a regression test, and ensured existing tests, linter and formatter pass.