### PR TITLE
Docs: Fix stale symlink rationale in local development guide

### DIFF
--- a/docs/LocalDevelopment.md
+++ b/docs/LocalDevelopment.md
@@ -39,7 +39,7 @@ Our recommended workflow is to use [`yarn link`][1] to register local `metro` pa
 
 3. **Configure Metro `watchFolders` to work with our linked packages**
 
-    Because `yarn link` has included files outside of the immediate React Native project folder, we need to inform Metro that this set of files exists (as it will not automatically follow the symlinks). Add the following to your `metro.config.js`:
+    Because `yarn link` has included files outside of the immediate React Native project folder, we need to inform Metro that this set of files exists. Metro follows symlinks, but a symlink's target must itself be within `projectRoot` or `watchFolders` to be resolvable. Add the following to your `metro.config.js`:
 
     ```diff
     + const path = require('path');


### PR DESCRIPTION
Summary:
The local development guide tells you to configure `watchFolders` "as it will not automatically follow the symlinks". Metro does follow symlinks, the requirement is that the symlink's target must itself be under `projectRoot` or `watchFolders` to be resolvable, which is how it's already put under [`watchFolders`](https://metrobundler.dev/docs/configuration/#watchfolders

Changelog: Internal