### PR TITLE
metro-file-map: Vendor `walker` and remove the dependency

### DIFF
--- a/packages/metro-file-map/package.json
+++ b/packages/metro-file-map/package.json
@@ -26,8 +26,7 @@
     "invariant": "^2.2.4",
     "jest-worker": "^29.7.0",
     "micromatch": "^4.0.4",
-    "nullthrows": "^1.1.1",
-    "walker": "^1.0.7"
+    "nullthrows": "^1.1.1"
   },
   "devDependencies": {
     "slash": "^3.0.0"

--- a/packages/metro-file-map/src/third-party/LICENSE.APACHE2
+++ b/packages/metro-file-map/src/third-party/LICENSE.APACHE2
@@ -1,0 +1,13 @@
+Copyright 2013 Naitik Shah
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/metro-file-map/src/third-party/walker.js
+++ b/packages/metro-file-map/src/third-party/walker.js
@@ -1,0 +1,155 @@
+/**
+ * Portions (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * Copyright 2013 Naitik Shah
+ *
+ * Vendored from the `walker` package, version 1.0.8, and licensed under the
+ * Apache License 2.0 found in LICENSE.APACHE2 in this directory:
+ * https://github.com/daaku/nodejs-walker
+ */
+
+import type {Stats} from 'node:fs';
+
+import EventEmitter from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+
+type EntryListener = (entry: string, stat: Stats) => void;
+
+type EventListeners = {
+  blockDevice: EntryListener,
+  characterDevice: EntryListener,
+  dir: EntryListener,
+  end: () => void,
+  entry: EntryListener,
+  error: (error: Error, entry: string, stat: ?Stats) => void,
+  fifo: EntryListener,
+  file: EntryListener,
+  socket: EntryListener,
+  symlink: EntryListener,
+};
+
+type EntryEvent = Exclude<keyof EventListeners, 'end' | 'entry' | 'error'>;
+
+/**
+ * Emitted when the type of an entry could not be determined.
+ */
+export class UnknownFileTypeError extends Error {
+  constructor(entry: string) {
+    super(`The type of ${entry} could not be determined.`);
+    this.name = 'UnknownFileTypeError';
+  }
+}
+
+/**
+ * To walk a directory. It's complicated (but it's async, so it must be fast).
+ *
+ * Walking starts as soon as the walker is constructed, so listeners must be
+ * attached synchronously.
+ */
+export default class Walker {
+  #emitter: EventEmitter = new EventEmitter();
+  #filterDir: (dir: string, stat: Stats) => boolean = () => true;
+  #pending: number = 0;
+
+  constructor(root: string) {
+    this.#go(root);
+  }
+
+  on<TEvent extends keyof EventListeners>(
+    event: TEvent,
+    listener: EventListeners[TEvent],
+  ): this {
+    this.#emitter.on(event, listener);
+    return this;
+  }
+
+  /**
+   * Setup a function to filter out directory entries. It is given a directory
+   * name, which if it returns true will include the directory and its
+   * children.
+   */
+  filterDir(fn: (dir: string, stat: Stats) => boolean): this {
+    this.#filterDir = fn;
+    return this;
+  }
+
+  /**
+   * Process a file or directory.
+   */
+  #go(entry: string): void {
+    this.#pending++;
+
+    fs.lstat(entry, (error, stat) => {
+      if (error) {
+        this.#emitter.emit('error', error, entry, null);
+        this.#doneOne();
+        return;
+      }
+
+      if (stat.isDirectory()) {
+        if (!this.#filterDir(entry, stat)) {
+          this.#doneOne();
+          return;
+        }
+
+        fs.readdir(entry, (readdirError, files) => {
+          if (readdirError) {
+            this.#emitter.emit('error', readdirError, entry, stat);
+            this.#doneOne();
+            return;
+          }
+
+          this.#emitEntry('dir', entry, stat);
+          for (const file of files) {
+            this.#go(path.join(entry, file));
+          }
+          this.#doneOne();
+        });
+        return;
+      }
+
+      if (stat.isSymbolicLink()) {
+        this.#emitEntry('symlink', entry, stat);
+      } else if (stat.isBlockDevice()) {
+        this.#emitEntry('blockDevice', entry, stat);
+      } else if (stat.isCharacterDevice()) {
+        this.#emitEntry('characterDevice', entry, stat);
+      } else if (stat.isFIFO()) {
+        this.#emitEntry('fifo', entry, stat);
+      } else if (stat.isSocket()) {
+        this.#emitEntry('socket', entry, stat);
+      } else if (stat.isFile()) {
+        this.#emitEntry('file', entry, stat);
+      } else {
+        this.#emitter.emit(
+          'error',
+          new UnknownFileTypeError(entry),
+          entry,
+          stat,
+        );
+      }
+      this.#doneOne();
+    });
+  }
+
+  #emitEntry(event: EntryEvent, entry: string, stat: Stats): void {
+    this.#emitter.emit('entry', entry, stat);
+    this.#emitter.emit(event, entry, stat);
+  }
+
+  #doneOne(): void {
+    if (--this.#pending === 0) {
+      this.#emitter.emit('end');
+    }
+  }
+}

--- a/packages/metro-file-map/src/watchers/FallbackWatcher.js
+++ b/packages/metro-file-map/src/watchers/FallbackWatcher.js
@@ -19,13 +19,12 @@ import type {
 } from '../flow-types';
 import type {FSWatcher, Stats} from 'node:fs';
 
+import Walker from '../third-party/walker';
 import {AbstractWatcher} from './AbstractWatcher';
 import * as common from './common';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-// $FlowFixMe[untyped-import] - Write libdefs for `walker`
-import walker from 'walker';
 
 const platform = os.platform();
 
@@ -437,7 +436,7 @@ function recReaddir(
   errorCallback: Error => void,
   ignored: ?RegExp,
 ) {
-  const walk = walker(dir);
+  const walk = new Walker(dir);
   if (ignored) {
     walk.filterDir(
       (currentDir: string) =>

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -38,9 +38,6 @@ jest
     release: () => '',
   }))
   .mock('graceful-fs', () => jest.requireMock('node:fs'))
-  // The third-party `walker` (used by metro-file-map's FallbackWatcher) requires
-  // the unprefixed 'fs', so alias it to the same in-memory fs as 'node:fs'.
-  .mock('fs', () => jest.requireMock('node:fs'))
   .spyOn(console, 'warn')
   .mockImplementation(() => {});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,7 +5924,7 @@ vlq@^1.0.0:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.0.tgz#8101be90843422954c2b13eb27f2f3122bdcc806"
   integrity sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==
 
-walker@^1.0.7, walker@^1.0.8:
+walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==


### PR DESCRIPTION

## Summary

`metro-file-map` depends on `walker` for `FallbackWatcher`'s initial crawl only. It hasn't received updates since 2021 and pulls in two other dependencies, yet is only ~120 lines. For that alone, vendoring is preferable to the supply chain risk.

There's also a known Metro bug we can't work around with `walker` as-is: directory events only fire after walker has statted their contents, so we can't attach a watch to the directory until after a short delay. Files added between the initial enumeration and the watch being attached are missed - and this is common when the directory is immediately populated eg by a package installation. This PR doesn't fix that, but it unblocks the follow up.

This is a mostly verbatim port that just adds Flow typing, ESM syntax, and updates an import from `fs` to Metro-convention `node:fs`.

Changelog: [Internal] Vendor the `walker` dependency into `metro-file-map`

## Test plan

```
yarn flow check
yarn typecheck-ts
yarn lint
yarn verify-api-snapshots
yarn build
yarn jest
```

All clean - full Jest run is 2662 passed, 1 skipped, across 147 suites.

`recReaddir` drives `FallbackWatcher`'s initial crawl, so `packages/metro-file-map/src/watchers/__tests__/integration-test.js` exercises the vendored code directly - 34 tests, including the `Fallback` matrix over new/changed/deleted files, symlinks (including to non-existent targets), pre-existing trees moved in and out of the watched root, and directory deletion. There's no dedicated unit test for `walker.js` itself.

One caveat: the first full run failed at `integration-test.js:92`, on the `NativeWatcher` directory-event assertion rather than `Fallback`. It passed in isolation and on a clean re-run of the whole suite, so it reads as a timing flake under parallel load, but I haven't bisected it against unmodified main to prove that.
