### PR TITLE
metro-file-map: Drop the walker dependency from FallbackWatcher

### DIFF
--- a/packages/metro-file-map/package.json
+++ b/packages/metro-file-map/package.json
@@ -26,8 +26,7 @@
     "invariant": "^2.2.4",
     "jest-worker": "^29.7.0",
     "micromatch": "^4.0.4",
-    "nullthrows": "^1.1.1",
-    "walker": "^1.0.7"
+    "nullthrows": "^1.1.1"
   },
   "devDependencies": {
     "slash": "^3.0.0"

--- a/packages/metro-file-map/src/watchers/FallbackWatcher.js
+++ b/packages/metro-file-map/src/watchers/FallbackWatcher.js
@@ -24,8 +24,6 @@ import * as common from './common';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-// $FlowFixMe[untyped-import] - Write libdefs for `walker`
-import walker from 'walker';
 
 const platform = os.platform();
 
@@ -41,6 +39,13 @@ const DELETE_EVENT = common.DELETE_EVENT;
  */
 const DEBOUNCE_MS = 100;
 
+/**
+ * The number of entries `recReaddir` visits at a time. Enough to keep the libuv
+ * thread pool saturated, few enough that a large tree does not queue up an
+ * unbounded number of fs requests.
+ */
+const CRAWL_CONCURRENCY = 32;
+
 export default class FallbackWatcher extends AbstractWatcher {
   readonly #changeTimers: Map<string, TimeoutID> = new Map();
   readonly #dirRegistry: {
@@ -53,25 +58,26 @@ export default class FallbackWatcher extends AbstractWatcher {
   async startWatching(): Promise<void> {
     this.#watchdir(this.root);
 
-    await new Promise(resolve => {
-      recReaddir(
-        this.root,
-        dir => {
-          this.#watchdir(dir);
-        },
-        filename => {
-          this.#register(filename, 'f');
-        },
-        symlink => {
-          this.#register(symlink, 'l');
-        },
-        () => {
-          resolve();
-        },
-        this.#checkedEmitError,
-        this.ignored,
-      );
-    });
+    await recReaddir(
+      this.root,
+      dir => {
+        this.#watchdir(dir);
+      },
+      filename => {
+        this.#register(filename, 'f');
+      },
+      symlink => {
+        this.#register(symlink, 'l');
+      },
+      this.#checkedEmitError,
+      this.ignored,
+    );
+
+    if (platform === 'win32') {
+      // Inherited from sane: win32 needs a settling period after the watches
+      // are registered before events can be relied on.
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
   }
 
   /**
@@ -297,7 +303,7 @@ export default class FallbackWatcher extends AbstractWatcher {
         ) {
           return;
         }
-        recReaddir(
+        await recReaddir(
           path.resolve(this.root, relativePath),
           (dir, stats) => {
             if (this.#watchdir(dir)) {
@@ -338,7 +344,6 @@ export default class FallbackWatcher extends AbstractWatcher {
               });
             }
           },
-          function endCallback() {},
           this.#checkedEmitError,
           this.ignored,
         );
@@ -426,45 +431,67 @@ function isIgnorableFileError(error: Error | {code: string}) {
 }
 
 /**
- * Traverse a directory recursively calling `callback` on every directory.
+ * Traverse a directory recursively, reporting every entry with its stats.
+ *
+ * Entries are visited depth-first by a bounded pool, so neither the queue of
+ * pending entries nor the number of in-flight fs requests grows with the size
+ * of the tree.
  */
-function recReaddir(
-  dir: string,
+async function recReaddir(
+  root: string,
   dirCallback: (string, Stats) => void,
   fileCallback: (string, Stats) => void,
   symlinkCallback: (string, Stats) => void,
-  endCallback: () => void,
   errorCallback: Error => void,
   ignored: ?RegExp,
-) {
-  const walk = walker(dir);
-  if (ignored) {
-    walk.filterDir(
-      (currentDir: string) =>
-        !common.posixPathMatchesPattern(ignored, currentDir),
-    );
-  }
-  walk
-    .on('dir', normalizeProxy(dirCallback))
-    .on('file', normalizeProxy(fileCallback))
-    .on('symlink', normalizeProxy(symlinkCallback))
-    .on('error', errorCallback)
-    .on('end', () => {
-      if (platform === 'win32') {
-        setTimeout(endCallback, 1000);
-      } else {
-        endCallback();
-      }
-    });
-}
+): Promise<void> {
+  const pending = [root];
 
-/**
- * Returns a callback that when called will normalize a path and call the
- * original callback
- */
-function normalizeProxy<T>(
-  callback: (filepath: string, stats: Stats) => T,
-): (string, Stats) => T {
-  return (filepath: string, stats: Stats) =>
-    callback(path.normalize(filepath), stats);
+  const visit = async (entry: string) => {
+    let stats;
+    let names;
+    try {
+      stats = await fsPromises.lstat(entry);
+      if (!stats.isDirectory()) {
+        if (stats.isSymbolicLink()) {
+          symlinkCallback(entry, stats);
+        } else if (stats.isFile()) {
+          fileCallback(entry, stats);
+        }
+        return;
+      }
+      if (ignored != null && common.posixPathMatchesPattern(ignored, entry)) {
+        return;
+      }
+      names = await fsPromises.readdir(entry);
+    } catch (error) {
+      errorCallback(error);
+      return;
+    }
+    dirCallback(entry, stats);
+    for (const name of names) {
+      pending.push(path.join(entry, name));
+    }
+  };
+
+  await new Promise((resolve, reject) => {
+    let active = 0;
+    const pump = () => {
+      while (active < CRAWL_CONCURRENCY) {
+        const entry = pending.pop();
+        if (entry == null) {
+          break;
+        }
+        active++;
+        visit(entry).then(() => {
+          active--;
+          pump();
+        }, reject);
+      }
+      if (active === 0) {
+        resolve();
+      }
+    };
+    pump();
+  });
 }

--- a/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
+++ b/packages/metro/src/DeltaBundler/__tests__/resolver-test.js
@@ -38,9 +38,6 @@ jest
     release: () => '',
   }))
   .mock('graceful-fs', () => jest.requireMock('node:fs'))
-  // The third-party `walker` (used by metro-file-map's FallbackWatcher) requires
-  // the unprefixed 'fs', so alias it to the same in-memory fs as 'node:fs'.
-  .mock('fs', () => jest.requireMock('node:fs'))
   .spyOn(console, 'warn')
   .mockImplementation(() => {});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5924,7 +5924,7 @@ vlq@^1.0.0:
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-1.0.0.tgz#8101be90843422954c2b13eb27f2f3122bdcc806"
   integrity sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==
 
-walker@^1.0.7, walker@^1.0.8:
+walker@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==


### PR DESCRIPTION

Summary:
`FallbackWatcher`'s `recReaddir` is the only consumer of `walker` (unmaintained since 2021, three deps) in Metro. `walker` schedules an `lstat` for every entry the moment the parent directory is read, so a crawl has as many in-flight `fs` requests. Those requests queue against a libuv thread pool of 4, so the concurrency buys nothing and the queued request state is pure memory overhead. Note - I *don't* believe this is responsible for `EMFILE: Too many open files`, as libuv's limits should prevent that.

This diff replaces it with a plain `async` `recReaddir` - a depth-first stack drained by a pool of at most 32 concurrent visits. The syscalls are identical, one `lstat` per entry and one `readdir` per directory, and so are the filters: `ignored` is still evaluated against a directory before it's descended into or reported. `endCallback` goes away in favour of awaiting, and `normalizeProxy` also goes because `path.join` already normalises.

The win32 settling delay is preserved and moves up into `startWatching`, which is the only place it was used.

Crawl of this repo's `node_modules`, 33,394 entries (3,160 directories, 30,054 files, 180 symlinks), median of 5 runs, macOS 25.6 on APFS, node 22.13.1:

| variant | wall (ms) | RSS (MB) | peak heap (MB) | max in-flight `readdir` |
|---|---|---|---|---|
| `walker` | 107.2 | 102.8 | 21.7 | 818 |
| bounded, 16 | 107.4 | 66.3 | 11.4 | 16 |
| bounded, 32 | 103.9 | 67.5 | 12.8 | 32 |
| bounded, 64 | 100.9 | 71.8 | 14.5 | 64 |
| bounded, 256 | 97.2 | 85.4 | 20.2 | 239 |

Both report the same 3,160/30,054/180 and issue the same number of syscalls. Wall time is constrained by the libuv pool concurrency, so 32 is chosen for the memory: **-34% RSS and -41% peak heap** against `walker`.

Changelog: Internal

Test Plan:
 - `watchers/__tests__/integration-test.js` on all supported OSes, which drives `FallbackWatcher` against a real temporary tree - new/changed/deleted files, symlinks to a file, to a directory and to a non-existent target, pre-existing files, a directory moved in from outside the watch root, a directory moved out, and deletion of a directory with files under it.

```
yarn jest packages/metro-file-map
yarn jest packages/metro/src/DeltaBundler/__tests__/resolver-test.js
yarn flow check
yarn lint
```