### PR TITLE
[0.85] TypeScript: Restore publishing of underscore-prefixed identifiers in .d.ts

### DIFF
--- a/packages/metro-file-map/types/watchers/NativeWatcher.d.ts
+++ b/packages/metro-file-map/types/watchers/NativeWatcher.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<6297e6ebfbeb2920f00b15cba9acbce2>>
+ * @generated SignedSource<<b68c5620efd3f5bec83279059d0d1b4e>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/watchers/NativeWatcher.js
@@ -50,5 +50,6 @@ declare class NativeWatcher extends AbstractWatcher {
    * End watching.
    */
   stopWatching(): Promise<void>;
+  _handleEvent(event: string, relativePath: string): void;
 }
 export default NativeWatcher;

--- a/packages/metro-source-map/types/B64Builder.d.ts
+++ b/packages/metro-source-map/types/B64Builder.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<f06808ae018ab95685d28a94a4c78bd9>>
+ * @generated SignedSource<<26fabb3db2058dda9c2a6e56de4728ce>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/B64Builder.js
@@ -48,5 +48,7 @@ declare class B64Builder {
    * Returns the string representation of the mappings.
    */
   toString(): string;
+  _writeByte(byte: number): void;
+  _realloc(): void;
 }
 export default B64Builder;

--- a/packages/metro-source-map/types/BundleBuilder.d.ts
+++ b/packages/metro-source-map/types/BundleBuilder.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<920bacbb8042b15a2cd4888e0ca47b8c>>
+ * @generated SignedSource<<c1cd2317d27c079743bc7c0e0fa4b379>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/BundleBuilder.js
@@ -31,7 +31,15 @@ import type {IndexMap, IndexMapSection, MixedSourceMap} from './source-map';
  * const map = builder.getMap();
  */
 export declare class BundleBuilder {
+  _file: string;
+  _sections: Array<IndexMapSection>;
+  _line: number;
+  _column: number;
+  _code: string;
+  _afterMappedContent: boolean;
   constructor(file: string);
+  _pushMapSection(map: MixedSourceMap): void;
+  _endMappedContent(): void;
   append(code: string, map: null | undefined | MixedSourceMap): this;
   getMap(): MixedSourceMap;
   getCode(): string;

--- a/packages/metro-source-map/types/Consumer/AbstractConsumer.d.ts
+++ b/packages/metro-source-map/types/Consumer/AbstractConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<098830f90b1f19dcdd5f55f1c02e3efb>>
+ * @generated SignedSource<<22565876862bd94effefabfc09cf8933>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/Consumer/AbstractConsumer.js
@@ -24,6 +24,7 @@ import type {
 } from './types';
 
 declare class AbstractConsumer implements IConsumer {
+  _sourceMap: {readonly file?: string};
   constructor(sourceMap: {readonly file?: string});
   originalPositionFor(
     generatedPosition: GeneratedPositionLookup,

--- a/packages/metro-source-map/types/Consumer/DelegatingConsumer.d.ts
+++ b/packages/metro-source-map/types/Consumer/DelegatingConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<4e6d6a38a375f6430761b6ae0220e309>>
+ * @generated SignedSource<<25b3906d78ba99d86fb91390016332ff>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/Consumer/DelegatingConsumer.js
@@ -34,6 +34,7 @@ declare class DelegatingConsumer implements IConsumer {
   static readonly ORIGINAL_ORDER: IterationOrder;
   static readonly GREATEST_LOWER_BOUND: LookupBias;
   static readonly LEAST_UPPER_BOUND: LookupBias;
+  _rootConsumer: IConsumer;
   constructor(sourceMap: MixedSourceMap);
   originalPositionFor(
     generatedPosition: GeneratedPositionLookup,

--- a/packages/metro-source-map/types/Consumer/MappingsConsumer.d.ts
+++ b/packages/metro-source-map/types/Consumer/MappingsConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<ccb269b70ed92c69d35a355e95baee67>>
+ * @generated SignedSource<<e2a6c983e649fe98c57dec4cc2e0aa65>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/Consumer/MappingsConsumer.js
@@ -22,6 +22,7 @@ import type {
   Mapping,
   SourcePosition,
 } from './types';
+import type {Number0} from 'ob1';
 
 import AbstractConsumer from './AbstractConsumer';
 /**
@@ -29,11 +30,18 @@ import AbstractConsumer from './AbstractConsumer';
  * `mappings` field and no sections).
  */
 declare class MappingsConsumer extends AbstractConsumer implements IConsumer {
+  _sourceMap: BasicSourceMap;
+  _decodedMappings: null | undefined | ReadonlyArray<Mapping>;
+  _normalizedSources: null | undefined | ReadonlyArray<string>;
   constructor(sourceMap: BasicSourceMap);
   originalPositionFor(
     generatedPosition: GeneratedPositionLookup,
   ): SourcePosition;
+  _decodeMappings(): Generator<Mapping, void, void>;
+  _normalizeAndCacheSources(): ReadonlyArray<string>;
+  _decodeAndCacheMappings(): ReadonlyArray<Mapping>;
   generatedMappings(): Iterable<Mapping>;
+  _indexOfSource(source: string): null | undefined | Number0;
   sourceContentFor(
     source: string,
     nullOnMissing: true,

--- a/packages/metro-source-map/types/Consumer/SectionsConsumer.d.ts
+++ b/packages/metro-source-map/types/Consumer/SectionsConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<cf526b3b5dc1b8fda7e13f65bd6dd2ba>>
+ * @generated SignedSource<<19e73dfc942bfc06b0a44f0488b16947>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-source-map/src/Consumer/SectionsConsumer.js
@@ -17,6 +17,7 @@
 
 import type {IndexMap} from '../source-map';
 import type {
+  GeneratedOffset,
   GeneratedPositionLookup,
   IConsumer,
   Mapping,
@@ -29,11 +30,15 @@ import AbstractConsumer from './AbstractConsumer';
  * `sections` field and no top-level mappings).
  */
 declare class SectionsConsumer extends AbstractConsumer implements IConsumer {
+  _consumers: ReadonlyArray<[GeneratedOffset, IConsumer]>;
   constructor(sourceMap: IndexMap);
   originalPositionFor(
     generatedPosition: GeneratedPositionLookup,
   ): SourcePosition;
   generatedMappings(): Iterable<Mapping>;
+  _consumerForPosition(
+    generatedPosition: GeneratedPositionLookup,
+  ): null | undefined | [GeneratedOffset, IConsumer];
   sourceContentFor(
     source: string,
     nullOnMissing: true,

--- a/packages/metro-symbolicate/types/ChromeHeapSnapshot.d.ts
+++ b/packages/metro-symbolicate/types/ChromeHeapSnapshot.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<4bb214316528dcf37b5f3a2aeef672ff>>
+ * @generated SignedSource<<d3f9345c8fb0ae1020ac1c3735b667f6>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/ChromeHeapSnapshot.js
@@ -36,6 +36,8 @@ export type ChromeHeapSnapshot = {
   trace_tree: RawBuffer;
 };
 export declare class ChromeHeapSnapshotProcessor {
+  readonly _snapshotData: ChromeHeapSnapshot;
+  readonly _globalStringTable: ChromeHeapSnapshotStringTable;
   constructor(snapshotData: ChromeHeapSnapshot);
   traceFunctionInfos(): ChromeHeapSnapshotRecordIterator;
   locations(): ChromeHeapSnapshotRecordIterator;
@@ -44,15 +46,24 @@ export declare class ChromeHeapSnapshotProcessor {
   traceTree(): ChromeHeapSnapshotRecordIterator;
 }
 declare class ChromeHeapSnapshotStringTable {
+  readonly _strings: Array<string>;
+  readonly _indexCache: Map<string, number>;
   constructor(strings: Array<string>);
   add(value: string): number;
   get(index: number): string;
+  _syncIndexCache(): void;
 }
 type ChromeHeapSnapshotFieldType = Array<string> | string;
 type DenormalizedRecordInput = Readonly<{
   [field: string]: string | number | ReadonlyArray<DenormalizedRecordInput>;
 }>;
 declare class ChromeHeapSnapshotRecordAccessor {
+  readonly _fieldToOffset: ReadonlyMap<string, number>;
+  readonly _fieldToType: ReadonlyMap<string, ChromeHeapSnapshotFieldType>;
+  readonly _recordSize: number;
+  readonly _buffer: RawBuffer;
+  readonly _globalStringTable: ChromeHeapSnapshotStringTable;
+  _position: number;
   constructor(
     buffer: RawBuffer,
     recordFields: Array<string>,
@@ -78,6 +89,22 @@ declare class ChromeHeapSnapshotRecordAccessor {
 
   protectedHasNext(): boolean;
   protectedTryMoveNext(): void;
+  /** Private methods */
+
+  _getRaw(field: string): number | RawBuffer;
+  _getScalar(field: string): string | number;
+  _setRaw(field: string, rawValue: number | RawBuffer): void;
+  _set(
+    field: string,
+    value: string | number | ReadonlyArray<DenormalizedRecordInput>,
+  ): void;
+  _setChildren(
+    field: string,
+    value: ReadonlyArray<DenormalizedRecordInput>,
+  ): void;
+  _encodeString(field: string, value: string): number;
+  _validatePosition(allowEnd?: boolean, position?: number): void;
+  _moveToPosition(nextPosition: number, allowEnd?: boolean): void;
 }
 declare class ChromeHeapSnapshotRecordIterator
   extends ChromeHeapSnapshotRecordAccessor

--- a/packages/metro-symbolicate/types/GoogleIgnoreListConsumer.d.ts
+++ b/packages/metro-symbolicate/types/GoogleIgnoreListConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<ccc6201d24a5a5a58eb55d27f6e45e86>>
+ * @generated SignedSource<<37cd1bfec704014c5260f0fd26c787dc>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/GoogleIgnoreListConsumer.js
@@ -37,6 +37,9 @@ type SourceNameNormalizer = (
   */
 declare class GoogleIgnoreListConsumer {
   constructor(map: MixedSourceMap, normalizeSourceFn?: SourceNameNormalizer);
+  _sourceMap: MixedSourceMap;
+  _normalizeSource: SourceNameNormalizer;
+  _ignoredSourceSet: null | undefined | Set<string>;
   /**
    * Returns `true` if the given source is in this map's ignore list, `false`
    * otherwise.
@@ -54,5 +57,31 @@ declare class GoogleIgnoreListConsumer {
    * `sources` field is the array that was passed into this method.
    */
   toArray(sources: ReadonlyArray<null | undefined | string>): Array<number>;
+  /**
+   * Prepares and caches a set of ignored sources for this map.
+   */
+  _getIgnoredSourceSet(): ReadonlySet<string>;
+  /**
+   * Collects ignored sources from the given map using the current source name
+   * normalization function. Handles both index maps (with sections) and plain
+   * maps.
+   *
+   * NOTE: If any sources are repeated in the map, we consider a source to be
+   * ignored as long as a source with the same normalized name is listed in AT
+   * LEAST one `x_google_ignoreList` array. Technically, this means we lose
+   * the granularity afforded by index maps and by the ability to repeat source
+   * names within a single `sources` array.
+   *
+   * Chrome's handling of duplicates is different: only the first occurrence of
+   * a given source is considered when determining if a source is ignored. It's
+   * unclear whether this is intentional. Absent a formal spec for
+   * `x_google_ignoreList`, we will diverge from Chrome for now.
+   *
+   * See: https://github.com/ChromeDevTools/devtools-frontend/blob/7afc9157b8d05de06e273284119e9c55a4eadb72/front_end/core/sdk/SourceMap.ts#L425-L429
+   */
+  _buildIgnoredSourceSet(
+    map: MixedSourceMap,
+    ignoredSourceSet: Set<string>,
+  ): void;
 }
 export default GoogleIgnoreListConsumer;

--- a/packages/metro-symbolicate/types/SourceMetadataMapConsumer.d.ts
+++ b/packages/metro-symbolicate/types/SourceMetadataMapConsumer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<ca5c64de15e1eb58ec8f523741b89502>>
+ * @generated SignedSource<<89d74f0d1fa133d80231a50f47338e1b>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/SourceMetadataMapConsumer.js
@@ -15,13 +15,23 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {FBSourcesArray, MixedSourceMap} from 'metro-source-map';
+import type {
+  FBSourceMetadata,
+  FBSourcesArray,
+  MixedSourceMap,
+} from 'metro-source-map';
 
 type Position = {readonly line: number; readonly column: number};
+type FunctionMapping = {
+  readonly line: number;
+  readonly column: number;
+  readonly name: string;
+};
 type SourceNameNormalizer = (
   $$PARAM_0$$: string,
   $$PARAM_1$$: {readonly sourceRoot?: null | undefined | string},
 ) => string;
+type MetadataMap = {[source: string]: null | undefined | FBSourceMetadata};
 /**
  * Consumes the `x_facebook_sources` metadata field from a source map and
  * exposes various queries on it.
@@ -38,6 +48,13 @@ type SourceNameNormalizer = (
  */
 declare class SourceMetadataMapConsumer {
   constructor(map: MixedSourceMap, normalizeSourceFn?: SourceNameNormalizer);
+  _sourceMap: MixedSourceMap;
+  _decodedFunctionMapCache: Map<
+    string,
+    null | undefined | ReadonlyArray<FunctionMapping>
+  >;
+  _normalizeSource: SourceNameNormalizer;
+  _metadataBySource: null | undefined | MetadataMap;
   /**
    * Retrieves a human-readable name for the function enclosing a particular
    * source location.
@@ -57,5 +74,26 @@ declare class SourceMetadataMapConsumer {
    * `sources` field is the array that was passed into this method.
    */
   toArray(sources: ReadonlyArray<string>): FBSourcesArray;
+  /**
+   * Prepares and caches a lookup table of metadata by source name.
+   */
+  _getMetadataBySource(): MetadataMap;
+  /**
+   * Decodes the function name mappings for the given source if needed, and
+   * retrieves a sorted, searchable array of mappings.
+   */
+  _getFunctionMappings(
+    source: string,
+  ): null | undefined | ReadonlyArray<FunctionMapping>;
+  /**
+   * Collects source metadata from the given map using the current source name
+   * normalization function. Handles both index maps (with sections) and plain
+   * maps.
+   *
+   * NOTE: If any sources are repeated in the map (which shouldn't happen in
+   * Metro, but is technically possible because of index maps) we only keep the
+   * metadata from the last occurrence of any given source.
+   */
+  _getMetadataObjectsBySourceNames(map: MixedSourceMap): MetadataMap;
 }
 export default SourceMetadataMapConsumer;

--- a/packages/metro-symbolicate/types/Symbolication.d.ts
+++ b/packages/metro-symbolicate/types/Symbolication.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<40fba27c16f56e64009443e70283d3b3>>
+ * @generated SignedSource<<d7e361fa3570566af1facd01589b7b38>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-symbolicate/src/Symbolication.js
@@ -16,9 +16,10 @@
  */
 
 import type {ChromeHeapSnapshot} from './ChromeHeapSnapshot';
-import type {MixedSourceMap} from 'metro-source-map';
+import type {HermesFunctionOffsets, MixedSourceMap} from 'metro-source-map';
 import type {Writable} from 'stream';
 
+import GoogleIgnoreListConsumer from './GoogleIgnoreListConsumer';
 import SourceMetadataMapConsumer from './SourceMetadataMapConsumer';
 import {type SourceMapConsumer as $$IMPORT_TYPEOF_1$$} from 'source-map';
 
@@ -131,11 +132,26 @@ declare class SymbolicationContext<ModuleIdsT> {
   parseFileName(str: string): ModuleIdsT;
 }
 declare class SingleMapSymbolicationContext extends SymbolicationContext<SingleMapModuleIds> {
+  readonly _segments: {
+    readonly [id: string]: {
+      readonly consumer: SourceMapConsumer;
+      readonly moduleOffsets: ReadonlyArray<number>;
+      readonly sourceFunctionsConsumer:
+        | null
+        | undefined
+        | SourceMetadataMapConsumer;
+      readonly hermesOffsets: null | undefined | HermesFunctionOffsets;
+      readonly googleIgnoreListConsumer: GoogleIgnoreListConsumer;
+    };
+  };
+  readonly _legacyFormat: boolean;
+  readonly _SourceMapConsumer: SourceMapConsumer;
   constructor(
     SourceMapConsumer: SourceMapConsumer,
     sourceMapContent: string | MixedSourceMap,
     options?: ContextOptionsInput,
   );
+  _initSegment(map: MixedSourceMap): void;
   symbolicateHermesMinidumpTrace(
     crashInfo: HermesMinidumpCrashInfo,
   ): SymbolicatedStackTrace;
@@ -150,11 +166,15 @@ declare class SingleMapSymbolicationContext extends SymbolicationContext<SingleM
   parseFileName(str: string): SingleMapModuleIds;
 }
 declare class DirectorySymbolicationContext extends SymbolicationContext<string> {
+  readonly _fileMaps: Map<string, SingleMapSymbolicationContext>;
+  readonly _rootDir: string;
+  readonly _SourceMapConsumer: SourceMapConsumer;
   constructor(
     SourceMapConsumer: SourceMapConsumer,
     rootDir: string,
     options?: ContextOptionsInput,
   );
+  _loadMap(mapFilename: string): SingleMapSymbolicationContext;
   getOriginalPositionDetailsFor(
     lineNumber: null | undefined | number,
     columnNumber: null | undefined | number,

--- a/packages/metro/types/Bundler.d.ts
+++ b/packages/metro/types/Bundler.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<fe2c52b16f1a3036429ec004623d3603>>
+ * @generated SignedSource<<3d5664309abdece0f247fcd0c53c3aaf>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Bundler.js
@@ -20,6 +20,7 @@ import type {TransformOptions} from './DeltaBundler/Worker';
 import type EventEmitter from 'events';
 import type {ConfigT} from 'metro-config';
 
+import Transformer from './DeltaBundler/Transformer';
 import DependencyGraph from './node-haste/DependencyGraph';
 
 export type BundlerOptions = Readonly<{
@@ -27,6 +28,9 @@ export type BundlerOptions = Readonly<{
   watch?: boolean;
 }>;
 declare class Bundler {
+  _depGraph: DependencyGraph;
+  _initializedPromise: Promise<void>;
+  _transformer: Transformer;
   constructor(config: ConfigT, options?: BundlerOptions);
   getWatcher(): EventEmitter;
   end(): Promise<void>;

--- a/packages/metro/types/DeltaBundler.d.ts
+++ b/packages/metro/types/DeltaBundler.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<4392a52adb92ee60889197cf5c38516d>>
+ * @generated SignedSource<<db564db653a99b07f3ad7585b2bed707>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler.js
@@ -23,6 +23,8 @@ import type {
   ReadOnlyGraph,
 } from './DeltaBundler/types';
 import type EventEmitter from 'events';
+
+import DeltaCalculator from './DeltaBundler/DeltaCalculator';
 
 export type {
   DeltaResult,
@@ -43,6 +45,8 @@ export type {
  * `clientId` param (which maps a client to a specific delta transformer).
  */
 declare class DeltaBundler<T = MixedOutput> {
+  _changeEventSource: EventEmitter;
+  _deltaCalculators: Map<Graph<T>, DeltaCalculator<T>>;
   constructor(changeEventSource: EventEmitter);
   end(): void;
   getDependencies(

--- a/packages/metro/types/DeltaBundler/DeltaCalculator.d.ts
+++ b/packages/metro/types/DeltaBundler/DeltaCalculator.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<1fbdc1ddc3526c8742b8c22d02311d38>>
+ * @generated SignedSource<<d06b53dd09157df95aeb941035d4ebf0>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/DeltaCalculator.js
@@ -16,6 +16,7 @@
  */
 
 import type {DeltaResult, Options} from './types';
+import type {ChangeEvent} from 'metro-file-map';
 
 import {Graph} from './Graph';
 import EventEmitter from 'events';
@@ -26,6 +27,14 @@ import EventEmitter from 'events';
  * traverse the whole dependency tree for trivial small changes.
  */
 declare class DeltaCalculator<T> extends EventEmitter {
+  _changeEventSource: EventEmitter;
+  _options: Options<T>;
+  _currentBuildPromise: null | undefined | Promise<DeltaResult<T>>;
+  _deletedFiles: Set<string>;
+  _modifiedFiles: Set<string>;
+  _addedFiles: Set<string>;
+  _requiresReset: boolean;
+  _graph: Graph<T>;
   constructor(
     entryPoints: ReadonlySet<string>,
     changeEventSource: EventEmitter,
@@ -49,5 +58,11 @@ declare class DeltaCalculator<T> extends EventEmitter {
    * plus some metadata.
    */
   getGraph(): Graph<T>;
+  _handleMultipleFileChanges: (changeEvent: ChangeEvent) => void;
+  _getChangedDependencies(
+    modifiedFiles: Set<string>,
+    deletedFiles: Set<string>,
+    addedFiles: Set<string>,
+  ): Promise<DeltaResult<T>>;
 }
 export default DeltaCalculator;

--- a/packages/metro/types/DeltaBundler/Graph.d.ts
+++ b/packages/metro/types/DeltaBundler/Graph.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<fc329765599e313b7d0cb6b45b7bbbdc>>
+ * @generated SignedSource<<2af7aa3b61c2afa4d8794e127666c226>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/Graph.js
@@ -15,12 +15,36 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
+/**
+ * Portions of this code are based on the Synchronous Cycle Collection
+ * algorithm described in:
+ *
+ * David F. Bacon and V. T. Rajan. 2001. Concurrent Cycle Collection in
+ * Reference Counted Systems. In Proceedings of the 15th European Conference on
+ * Object-Oriented Programming (ECOOP '01). Springer-Verlag, Berlin,
+ * Heidelberg, 207–235.
+ *
+ * Notable differences from the algorithm in the paper:
+ * 1. Our implementation uses the inverseDependencies set (which we already
+ *    have to maintain) instead of a separate refcount variable. A module's
+ *    reference count is equal to the size of its inverseDependencies set, plus
+ *    1 if it's an entry point of the graph.
+ * 2. We keep the "root buffer" (possibleCycleRoots) free of duplicates by
+ *    making it a Set, instead of storing a "buffered" flag on each node.
+ * 3. On top of tracking edges between nodes, we also count references between
+ *    nodes and entries in the importBundleNodes set.
+ */
+
+import type {RequireContext} from '../lib/contextModule';
 import type {
   Dependencies,
+  Dependency,
   GraphInputOptions,
   MixedOutput,
   Module,
+  ModuleData,
   Options,
+  ResolvedDependency,
   TransformInputOptions,
 } from './types';
 
@@ -31,6 +55,22 @@ export type Result<T> = {
   modified: Map<string, Module<T>>;
   deleted: Set<string>;
 };
+type Delta<T> = Readonly<{
+  added: Set<string>;
+  touched: Set<string>;
+  deleted: Set<string>;
+  updatedModuleData: ReadonlyMap<string, ModuleData<T>>;
+  baseModuleData: Map<string, ModuleData<T>>;
+  errors: ReadonlyMap<string, Error>;
+}>;
+type InternalOptions<T> = Readonly<{
+  lazy: boolean;
+  onDependencyAdd: () => unknown;
+  onDependencyAdded: () => unknown;
+  resolve: Options<T>['resolve'];
+  transform: Options<T>['transform'];
+  shallow: boolean;
+}>;
 export declare class Graph<T = MixedOutput> {
   readonly entryPoints: ReadonlySet<string>;
   readonly transformOptions: TransformInputOptions;
@@ -52,6 +92,32 @@ export declare class Graph<T = MixedOutput> {
     options: Options<T>,
   ): Promise<Result<T>>;
   initialTraverseDependencies(options: Options<T>): Promise<Result<T>>;
+  _buildDelta(
+    pathsToVisit: ReadonlySet<string>,
+    options: InternalOptions<T>,
+    moduleFilter?: (path: string) => boolean,
+  ): Promise<Delta<T>>;
+  _recursivelyCommitModule(
+    path: string,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+    commitOptions?: Readonly<{onlyRemove: boolean}>,
+  ): Module<T>;
+  _addDependency(
+    parentModule: Module<T>,
+    key: string,
+    dependency: Dependency,
+    requireContext: null | undefined | RequireContext,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ): void;
+  _removeDependency(
+    parentModule: Module<T>,
+    key: string,
+    dependency: Dependency,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ): void;
   /**
    * Collect a list of context modules which include a given file.
    */
@@ -70,4 +136,39 @@ export declare class Graph<T = MixedOutput> {
    * guarantee the same order between runs. This method mutates the passed graph.
    */
   reorderGraph(options: {shallow: boolean}): void;
+  _reorderDependencies(
+    module: Module<T>,
+    orderedDependencies: Map<string, Module<T>>,
+    options: {shallow: boolean},
+  ): void;
+  /** Garbage collection functions */
+
+  _incrementImportBundleReference(
+    dependency: ResolvedDependency,
+    parentModule: Module<T>,
+  ): void;
+  _decrementImportBundleReference(
+    dependency: ResolvedDependency,
+    parentModule: Module<T>,
+  ): void;
+  _markModuleInUse(module: Module<T>): void;
+  _children(
+    module: Module<T>,
+    options: InternalOptions<T>,
+  ): Iterator<Module<T>>;
+  _moduleSnapshot(module: Module<T>): ModuleData<T>;
+  _releaseModule(
+    module: Module<T>,
+    delta: Delta<T>,
+    options: InternalOptions<T>,
+  ): void;
+  _freeModule(module: Module<T>, delta: Delta<T>): void;
+  _markAsPossibleCycleRoot(module: Module<T>): void;
+  _collectCycles(delta: Delta<T>, options: InternalOptions<T>): void;
+  _markGray(module: Module<T>, options: InternalOptions<T>): void;
+  _scan(module: Module<T>, options: InternalOptions<T>): void;
+  _scanBlack(module: Module<T>, options: InternalOptions<T>): void;
+  _collectWhite(module: Module<T>, delta: Delta<T>): void;
+
+  /** End of garbage collection functions */
 }

--- a/packages/metro/types/DeltaBundler/Transformer.d.ts
+++ b/packages/metro/types/DeltaBundler/Transformer.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<74d76149d62fc6d50282472fa1e271fe>>
+ * @generated SignedSource<<15f603afc860c64c7acc5a6cfe2a6717>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/Transformer.js
@@ -15,14 +15,22 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {TransformResultWithSource} from '../DeltaBundler';
+import type {TransformResult, TransformResultWithSource} from '../DeltaBundler';
 import type {TransformOptions} from './Worker';
 import type {ConfigT} from 'metro-config';
+
+import WorkerFarm from './WorkerFarm';
+import {Cache} from 'metro-cache';
 
 type GetOrComputeSha1Fn = (
   $$PARAM_0$$: string,
 ) => Promise<Readonly<{content?: Buffer; sha1: string}>>;
 declare class Transformer {
+  _config: ConfigT;
+  _cache: Cache<TransformResult>;
+  _baseHash: string;
+  _getSha1: GetOrComputeSha1Fn;
+  _workerFarm: WorkerFarm;
   constructor(
     config: ConfigT,
     opts: Readonly<{getOrComputeSha1: GetOrComputeSha1Fn}>,

--- a/packages/metro/types/DeltaBundler/WorkerFarm.d.ts
+++ b/packages/metro/types/DeltaBundler/WorkerFarm.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<d9d13bcad23924cbcf706b93e621e91c>>
+ * @generated SignedSource<<bbd52f1dc5e4a9253455034b585115ac>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/DeltaBundler/WorkerFarm.js
@@ -16,11 +16,29 @@
  */
 
 import type {TransformResult} from '../DeltaBundler';
-import type {TransformerConfig, TransformOptions} from './Worker';
+import type {TransformerConfig, TransformOptions, Worker} from './Worker';
 import type {ConfigT} from 'metro-config';
+import type {Readable} from 'stream';
 
+type WorkerInterface = Readonly<
+  Omit<
+    Worker,
+    keyof {
+      end(): void | Promise<void>;
+      getStdout(): Readable;
+      getStderr(): Readable;
+    }
+  > & {
+    end(): void | Promise<void>;
+    getStdout(): Readable;
+    getStderr(): Readable;
+  }
+>;
 type TransformerResult = Readonly<{result: TransformResult; sha1: string}>;
 declare class WorkerFarm {
+  _config: ConfigT;
+  _transformerConfig: TransformerConfig;
+  _worker: WorkerInterface | Worker;
   constructor(config: ConfigT, transformerConfig: TransformerConfig);
   kill(): Promise<void>;
   transform(
@@ -28,5 +46,32 @@ declare class WorkerFarm {
     options: TransformOptions,
     fileBuffer?: Buffer,
   ): Promise<TransformerResult>;
+  _makeFarm(
+    absoluteWorkerPath: string,
+    exposedMethods: ReadonlyArray<string>,
+    numWorkers: number,
+  ): WorkerInterface;
+  _computeWorkerKey(
+    method: string,
+    filename: string,
+  ): null | undefined | string;
+  _formatGenericError(
+    err: Readonly<{message: string; stack?: string}>,
+    filename: string,
+  ): TransformError;
+  _formatBabelError(
+    err: Readonly<{
+      message: string;
+      stack?: string;
+      type?: string;
+      codeFrame?: unknown;
+      loc: {line?: number; column?: number};
+    }>,
+    filename: string,
+  ): TransformError;
 }
 export default WorkerFarm;
+declare class TransformError extends SyntaxError {
+  type: string;
+  constructor(message: string);
+}

--- a/packages/metro/types/HmrServer.d.ts
+++ b/packages/metro/types/HmrServer.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<48bfe42125bd22a8329f95a30fa90b64>>
+ * @generated SignedSource<<ab4c245134631e14db114a9d49da79d1>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/HmrServer.js
@@ -18,12 +18,24 @@ import type {
   RevisionId,
   default as IncrementalBundler,
 } from './IncrementalBundler';
-import type {ConfigT} from 'metro-config';
+import type {GraphOptions} from './shared/types';
+import type {ConfigT, RootPerfLogger} from 'metro-config';
+import type {
+  HmrErrorMessage,
+  HmrUpdateMessage,
+} from 'metro-runtime/src/modules/types';
 
 export type Client = {
   optedIntoHMR: boolean;
   revisionIds: Array<RevisionId>;
   readonly sendFn: ($$PARAM_0$$: string) => void;
+};
+type ClientGroup = {
+  readonly clients: Set<Client>;
+  clientUrl: URL;
+  revisionId: RevisionId;
+  readonly unlisten: () => void;
+  readonly graphOptions: GraphOptions;
 };
 /**
  * The HmrServer (Hot Module Reloading) implements a lightweight interface
@@ -35,6 +47,10 @@ export type Client = {
  * `onClientConnect`, `onClientDisconnect` and `onClientError` methods).
  */
 declare class HmrServer<TClient extends Client> {
+  _config: ConfigT;
+  _bundler: IncrementalBundler;
+  _createModuleId: (path: string) => number;
+  _clientGroups: Map<RevisionId, ClientGroup>;
   constructor(
     bundler: IncrementalBundler,
     createModuleId: (path: string) => number,
@@ -44,6 +60,11 @@ declare class HmrServer<TClient extends Client> {
     requestUrl: string,
     sendFn: (data: string) => void,
   ) => Promise<Client>;
+  _registerEntryPoint(
+    client: Client,
+    originalRequestUrl: string,
+    sendFn: (data: string) => void,
+  ): Promise<void>;
   onClientMessage: (
     client: TClient,
     message: string | Buffer | ArrayBuffer | Array<Buffer>,
@@ -51,5 +72,27 @@ declare class HmrServer<TClient extends Client> {
   ) => Promise<void>;
   onClientError: (client: TClient, e: Error) => void;
   onClientDisconnect: (client: TClient) => void;
+  _handleFileChange(
+    group: ClientGroup,
+    options: {isInitialUpdate: boolean},
+    changeEvent:
+      | null
+      | undefined
+      | {
+          readonly logger: null | undefined | RootPerfLogger;
+          readonly changeId?: string;
+        },
+  ): Promise<void>;
+  _prepareMessage(
+    group: ClientGroup,
+    options: {isInitialUpdate: boolean},
+    changeEvent:
+      | null
+      | undefined
+      | {
+          readonly logger: null | undefined | RootPerfLogger;
+          readonly changeId?: string;
+        },
+  ): Promise<HmrUpdateMessage | HmrErrorMessage>;
 }
 export default HmrServer;

--- a/packages/metro/types/IncrementalBundler.d.ts
+++ b/packages/metro/types/IncrementalBundler.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<7ce634e158aa8f2ac74e32940e9e97c1>>
+ * @generated SignedSource<<0ec72971869a882d97b381e3f1baa922>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/IncrementalBundler.js
@@ -47,6 +47,11 @@ export type IncrementalBundlerOptions = Readonly<{
   watch?: boolean;
 }>;
 declare class IncrementalBundler {
+  _config: ConfigT;
+  _bundler: Bundler;
+  _deltaBundler: DeltaBundler;
+  _revisionsById: Map<RevisionId, Promise<GraphRevision>>;
+  _revisionsByGraphId: Map<GraphId, Promise<GraphRevision>>;
   static revisionIdFromString: (str: string) => RevisionId;
   constructor(config: ConfigT, options?: IncrementalBundlerOptions);
   end(): Promise<void>;
@@ -90,6 +95,9 @@ declare class IncrementalBundler {
     reset: boolean,
   ): Promise<{delta: DeltaResult; revision: GraphRevision}>;
   endGraph(graphId: GraphId): Promise<void>;
+  _getAbsoluteEntryFiles(
+    entryFiles: ReadonlyArray<string>,
+  ): Promise<ReadonlyArray<string>>;
   ready(): Promise<void>;
 }
 export default IncrementalBundler;

--- a/packages/metro/types/ModuleGraph/worker/collectDependencies.d.ts
+++ b/packages/metro/types/ModuleGraph/worker/collectDependencies.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<f072a86187014259ece27c02d9abfd6a>>
+ * @generated SignedSource<<ab2d1203f736c3032c6b9d15cc74680b>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/ModuleGraph/worker/collectDependencies.js
@@ -132,6 +132,7 @@ export type ImportQualifier = Readonly<{
   contextParams?: RequireContextParams;
 }>;
 declare class DependencyRegistry {
+  _dependencies: Map<string, InternalDependency>;
   registerDependency(qualifier: ImportQualifier): InternalDependency;
   getDependencies(): Array<InternalDependency>;
 }

--- a/packages/metro/types/Server.d.ts
+++ b/packages/metro/types/Server.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<a4fd26fa84b68e8bc2b3c32bcf36e7bc>>
+ * @generated SignedSource<<03b526801403adb05b3b0f6c25b25ed5>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Server.js
@@ -16,16 +16,38 @@
  */
 
 import type {AssetData} from './Assets';
+import type {ExplodedSourceMap} from './DeltaBundler/Serializers/getExplodedSourceMap';
 import type {RamBundleInfo} from './DeltaBundler/Serializers/getRamBundleInfo';
-import type {BuildOptions, BundleOptions} from './shared/types';
+import type {
+  Module,
+  ReadOnlyDependencies,
+  ReadOnlyGraph,
+  TransformInputOptions,
+} from './DeltaBundler/types';
+import type {RevisionId} from './IncrementalBundler';
+import type {GraphId} from './lib/getGraphId';
+import type {Reporter} from './lib/reporting';
+import type {
+  BuildOptions,
+  BundleOptions,
+  GraphOptions,
+  ResolverInputOptions,
+  SplitBundleOptions,
+} from './shared/types';
 import type {IncomingMessage} from 'connect';
 import type {ServerResponse} from 'http';
-import type {ConfigT} from 'metro-config';
+import type {ConfigT, RootPerfLogger} from 'metro-config';
+import type {
+  ActionLogEntryData,
+  ActionStartLogEntry,
+} from 'metro-core/private/Logger';
 import type {CustomResolverOptions} from 'metro-resolver/private/types';
 import type {CustomTransformOptions} from 'metro-transform-worker';
 
 import IncrementalBundler from './IncrementalBundler';
+import MultipartResponse from './Server/MultipartResponse';
 import {SourcePathsMode} from './shared/types';
+import {Logger} from 'metro-core';
 
 export type SegmentLoadData = {
   [$$Key$$: number]: [Array<number>, null | undefined | number];
@@ -37,33 +59,183 @@ export type BundleMetadata = {
   segmentHashes: Array<string>;
   segmentLoadData: SegmentLoadData;
 };
+type ProcessStartContext = Omit<
+  SplitBundleOptions,
+  keyof {
+    readonly buildNumber: number;
+    readonly bundleOptions: BundleOptions;
+    readonly graphId: GraphId;
+    readonly graphOptions: GraphOptions;
+    readonly mres: MultipartResponse | ServerResponse;
+    readonly req: IncomingMessage;
+    readonly revisionId?: null | undefined | RevisionId;
+    readonly bundlePerfLogger: RootPerfLogger;
+    readonly requestStartTimestamp: number;
+  }
+> & {
+  readonly buildNumber: number;
+  readonly bundleOptions: BundleOptions;
+  readonly graphId: GraphId;
+  readonly graphOptions: GraphOptions;
+  readonly mres: MultipartResponse | ServerResponse;
+  readonly req: IncomingMessage;
+  readonly revisionId?: null | undefined | RevisionId;
+  readonly bundlePerfLogger: RootPerfLogger;
+  readonly requestStartTimestamp: number;
+};
+type ProcessDeleteContext = {
+  readonly graphId: GraphId;
+  readonly req: IncomingMessage;
+  readonly res: ServerResponse;
+};
+type ProcessEndContext<T> = Omit<
+  ProcessStartContext,
+  keyof {readonly result: T}
+> & {readonly result: T};
 export type ServerOptions = Readonly<{
   hasReducedPerformance?: boolean;
   onBundleBuilt?: (bundlePath: string) => void;
   watch?: boolean;
 }>;
+type FetchTiming = {
+  graphId: GraphId;
+  startTime: number;
+  endTime: number | null;
+  isPrefetch: boolean;
+};
 declare class Server {
+  _bundler: IncrementalBundler;
+  _config: ConfigT;
+  _createModuleId: (path: string) => number;
+  _isEnded: boolean;
+  _logger: typeof Logger;
+  _nextBundleBuildNumber: number;
+  _platforms: Set<string>;
+  _reporter: Reporter;
+  _serverOptions: ServerOptions | void;
+  _allowedSuffixesForSourceRequests: ReadonlyArray<string>;
+  _sourceRequestRoutingMap: ReadonlyArray<
+    [pathnamePrefix: string, normalizedRootDir: string]
+  >;
+  _fetchTimings: Array<FetchTiming>;
+  _activeFetchCount: number;
   constructor(config: ConfigT, options?: ServerOptions);
   end(): void;
   getBundler(): IncrementalBundler;
   getCreateModuleId(): (path: string) => number;
+  _serializeGraph(
+    $$PARAM_0$$: Readonly<{
+      splitOptions: SplitBundleOptions;
+      prepend: ReadonlyArray<Module>;
+      graph: ReadOnlyGraph;
+    }>,
+  ): Promise<{code: string; map: string}>;
   build(
     bundleOptions: BundleOptions,
     $$PARAM_1$$?: BuildOptions,
   ): Promise<{code: string; map: string; assets?: ReadonlyArray<AssetData>}>;
   getRamBundleInfo(options: BundleOptions): Promise<RamBundleInfo>;
   getAssets(options: BundleOptions): Promise<ReadonlyArray<AssetData>>;
+  _getAssetsFromDependencies(
+    dependencies: ReadOnlyDependencies,
+    platform: null | undefined | string,
+  ): Promise<ReadonlyArray<AssetData>>;
   getOrderedDependencyPaths(options: {
     readonly dev: boolean;
     readonly entryFile: string;
     readonly minify: boolean;
     readonly platform: null | undefined | string;
   }): Promise<Array<string>>;
+  _rangeRequestMiddleware(
+    req: IncomingMessage,
+    res: ServerResponse,
+    data: string | Buffer,
+    assetPath: string,
+  ): Buffer | string;
+  _processSingleAssetRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+  ): Promise<void>;
   processRequest: (
     $$PARAM_0$$: IncomingMessage,
     $$PARAM_1$$: ServerResponse,
     $$PARAM_2$$: (e: null | undefined | Error) => void,
   ) => void;
+  _parseOptions(url: string): BundleOptions;
+  _rewriteAndNormalizeUrl(requestUrl: string): string;
+  _processRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: ($$PARAM_0$$: null | undefined | Error) => void,
+  ): Promise<void>;
+  _processSourceRequest(
+    relativeFilePathname: string,
+    rootDir: string,
+    res: ServerResponse,
+  ): Promise<void>;
+  _createRequestProcessor<T>($$PARAM_0$$: {
+    readonly bundleType: 'assets' | 'bundle' | 'map';
+    readonly createStartEntry: (
+      context: ProcessStartContext,
+    ) => ActionLogEntryData;
+    readonly createEndEntry: (
+      context: ProcessEndContext<T>,
+    ) => Partial<ActionStartLogEntry>;
+    readonly build: (context: ProcessStartContext) => Promise<T>;
+    readonly delete?: (context: ProcessDeleteContext) => Promise<void>;
+    readonly finish: (context: ProcessEndContext<T>) => void;
+  }): (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number;
+      bundlePerfLogger: RootPerfLogger;
+    }>,
+  ) => Promise<void>;
+  _processBundleRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number;
+      bundlePerfLogger: RootPerfLogger;
+    }>,
+  ) => Promise<void>;
+  _getSortedModules(graph: ReadOnlyGraph): ReadonlyArray<Module>;
+  _processSourceMapRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number;
+      bundlePerfLogger: RootPerfLogger;
+    }>,
+  ) => Promise<void>;
+  _processAssetsRequest: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    bundleOptions: BundleOptions,
+    buildContext: Readonly<{
+      buildNumber: number;
+      bundlePerfLogger: RootPerfLogger;
+    }>,
+  ) => Promise<void>;
+  _symbolicate(req: IncomingMessage, res: ServerResponse): Promise<void>;
+  _explodedSourceMapForBundleOptions(
+    bundleOptions: BundleOptions,
+  ): Promise<ExplodedSourceMap>;
+  _resolveWatchFolderPrefix(
+    filePath: string,
+  ): {rootDir: string; filePath: string} | null;
+  _resolveRelativePath(
+    filePath: string,
+    $$PARAM_1$$: Readonly<{
+      relativeTo: 'project' | 'server';
+      resolverOptions: ResolverInputOptions;
+      transformOptions: TransformInputOptions;
+    }>,
+  ): Promise<string>;
   getNewBuildNumber(): number;
   getPlatforms(): ReadonlyArray<string>;
   getWatchFolders(): ReadonlyArray<string>;
@@ -100,6 +272,10 @@ declare class Server {
     sourceUrl: null;
     sourcePaths: SourcePathsMode;
   };
+  _getServerRootDir(): string;
+  _getEntryPointAbsolutePath(entryFile: string): string;
   ready(): Promise<void>;
+  _shouldAddModuleToIgnoreList(module: Module): boolean;
+  _getModuleSourceUrl(module: Module, mode: SourcePathsMode): string;
 }
 export default Server;

--- a/packages/metro/types/lib/BatchProcessor.d.ts
+++ b/packages/metro/types/lib/BatchProcessor.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<44408f85f4340c918786727e30822c20>>
+ * @generated SignedSource<<5872ab26db1c8f4499c971170c5012c4>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/BatchProcessor.js
@@ -14,6 +14,8 @@
  *   js1 build metro-ts-defs (internal) OR
  *   yarn run build-ts-defs (OSS) 
  */
+
+import {setTimeout} from 'timers';
 
 type ProcessBatch<TItem, TResult> = (
   batch: Array<TItem>,
@@ -23,6 +25,11 @@ type BatchProcessorOptions = {
   maximumItems: number;
   concurrency: number;
 };
+type QueueItem<TItem, TResult> = {
+  item: TItem;
+  reject: (error: unknown) => unknown;
+  resolve: (result: TResult) => unknown;
+};
 /**
  * We batch items together trying to minimize their processing, for example as
  * network queries. For that we wait a small moment before processing a batch.
@@ -31,10 +38,23 @@ type BatchProcessorOptions = {
  * processing right away.
  */
 declare class BatchProcessor<TItem, TResult> {
+  _currentProcessCount: number;
+  _options: BatchProcessorOptions;
+  _processBatch: ProcessBatch<TItem, TResult>;
+  _queue: Array<QueueItem<TItem, TResult>>;
+  _timeoutHandle: null | undefined | ReturnType<typeof setTimeout>;
   constructor(
     options: BatchProcessorOptions,
     processBatch: ProcessBatch<TItem, TResult>,
   );
+  _onBatchFinished(): void;
+  _onBatchResults(
+    jobs: Array<QueueItem<TItem, TResult>>,
+    results: Array<TResult>,
+  ): void;
+  _onBatchError(jobs: Array<QueueItem<TItem, TResult>>, error: unknown): void;
+  _processQueue(): void;
+  _processQueueOnceReady(): void;
   queue(item: TItem): Promise<TResult>;
   getQueueLength(): number;
 }

--- a/packages/metro/types/lib/JsonReporter.d.ts
+++ b/packages/metro/types/lib/JsonReporter.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<bfc4caf223ec55afbed87fbd905607ea>>
+ * @generated SignedSource<<e7173f8dc5e076fd37b9a1cecd581f58>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/JsonReporter.js
@@ -33,6 +33,7 @@ export type SerializedEvent<
 declare class JsonReporter<
   TEvent extends {readonly [$$Key$$: string]: unknown},
 > {
+  _stream: Writable;
   constructor(stream: Writable);
   /**
    * There is a special case for errors because they have non-enumerable fields.

--- a/packages/metro/types/lib/RamBundleParser.d.ts
+++ b/packages/metro/types/lib/RamBundleParser.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<7be940ed3f4c6dffc465780640e301ec>>
+ * @generated SignedSource<<ebddbde1dcdecbbee129fd96caaf3bb0>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/RamBundleParser.js
@@ -24,7 +24,12 @@
  * getModule(): returns the code for the specified module.
  */
 declare class RamBundleParser {
+  _buffer: Buffer;
+  _numModules: number;
+  _startupCodeLength: number;
+  _startOffset: number;
   constructor(buffer: Buffer);
+  _readPosition(pos: number): number;
   getStartupCode(): string;
   getModule(id: number): string;
 }

--- a/packages/metro/types/lib/TerminalReporter.d.ts
+++ b/packages/metro/types/lib/TerminalReporter.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<14645ae49e4ed5ce74bdd181db9098d4>>
+ * @generated SignedSource<<8218e45d6b5186264c4bf9e54086708a>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/lib/TerminalReporter.js
@@ -15,9 +15,17 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-import type {ReportableEvent} from './reporting';
+import type {BundleDetails, ReportableEvent} from './reporting';
 import type {Terminal} from 'metro-core';
+import type {HealthCheckResult, WatcherStatus} from 'metro-file-map';
 
+type BundleProgress = {
+  bundleDetails: BundleDetails;
+  transformedFileCount: number;
+  totalFileCount: number;
+  ratio: number;
+  isPrefetch?: boolean;
+};
 export type TerminalReportableEvent =
   | ReportableEvent
   | {
@@ -33,13 +41,81 @@ export type TerminalReportableEvent =
     }
   | {type: 'unstable_server_menu_updated'; message: string}
   | {type: 'unstable_server_menu_cleared'};
+type BuildPhase = 'in_progress' | 'done' | 'failed';
+interface SnippetError extends Error {
+  code?: string;
+  filename?: string;
+  snippet?: string;
+}
 /**
  * We try to print useful information to the terminal for interactive builds.
  * This implements the `Reporter` interface from the './reporting' module.
  */
 declare class TerminalReporter {
+  /**
+   * The bundle builds for which we are actively maintaining the status on the
+   * terminal, ie. showing a progress bar. There can be several bundles being
+   * built at the same time.
+   */
+  _activeBundles: Map<string, BundleProgress>;
+  _interactionStatus: null | undefined | string;
+  _scheduleUpdateBundleProgress: {
+    (data: {
+      buildID: string;
+      transformedFileCount: number;
+      totalFileCount: number;
+    }): void;
+    cancel(): void;
+  };
+  _prevHealthCheckResult: null | undefined | HealthCheckResult;
   readonly terminal: Terminal;
   constructor(terminal: Terminal);
+  /**
+   * Construct a message that represents the progress of a
+   * single bundle build, for example:
+   *
+   *     BUNDLE path/to/bundle.js ▓▓▓▓▓░░░░░░░░░░░ 36.6% (4790/7922)
+   */
+  _getBundleStatusMessage(
+    $$PARAM_0$$: BundleProgress,
+    phase: BuildPhase,
+  ): string;
+  _logBundleBuildDone(buildID: string): void;
+  _logBundleBuildFailed(buildID: string): void;
+  _logInitializing(port: number, hasReducedPerformance: boolean): void;
+  _logInitializingFailed(port: number, error: SnippetError): void;
+  /**
+   * This function is only concerned with logging and should not do state
+   * or terminal status updates.
+   */
+  _log(event: TerminalReportableEvent): void;
+  /**
+   * We do not want to log the whole stacktrace for bundling error, because
+   * these are operational errors, not programming errors, and the stacktrace
+   * is not actionable to end users.
+   */
+  _logBundlingError(error: SnippetError): void;
+  _logWorkerChunk(origin: 'stdout' | 'stderr', chunk: string): void;
+  _updateBundleProgress($$PARAM_0$$: {
+    buildID: string;
+    transformedFileCount: number;
+    totalFileCount: number;
+  }): void;
+  /**
+   * This function is exclusively concerned with updating the internal state.
+   * No logging or status updates should be done at this point.
+   */
+  _updateState(event: TerminalReportableEvent): void;
+  /**
+   * Return a status message that is always consistent with the current state
+   * of the application. Having this single function ensures we don't have
+   * different callsites overriding each other status messages.
+   */
+  _getStatusMessage(): string;
+  _logHmrClientError(e: Error): void;
+  _logWarning(message: string): void;
+  _logWatcherHealthCheckResult(result: HealthCheckResult): void;
+  _logWatcherStatus(status: WatcherStatus): void;
   /**
    * Single entry point for reporting events. That allows us to implement the
    * corresponding JSON reporter easily and have a consistent reporting.

--- a/packages/metro/types/node-haste/DependencyGraph.d.ts
+++ b/packages/metro/types/node-haste/DependencyGraph.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<1cc985f3869f7db49aca7daeca848b82>>
+ * @generated SignedSource<<13f1483d2a732241f8d9eae463399b0e>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/node-haste/DependencyGraph.js
@@ -21,10 +21,32 @@ import type {
 } from '../DeltaBundler/types';
 import type {ResolverInputOptions} from '../shared/types';
 import type {ConfigT} from 'metro-config';
+import type {
+  ChangeEvent,
+  FileSystem,
+  HasteMap,
+  HealthCheckResult,
+  WatcherStatus,
+  default as MetroFileMap,
+} from 'metro-file-map';
 
+import {ModuleResolver} from './DependencyGraph/ModuleResolution';
 import EventEmitter from 'events';
 
 declare class DependencyGraph extends EventEmitter {
+  _config: ConfigT;
+  _haste: MetroFileMap;
+  _fileSystem: FileSystem;
+  _hasteMap: HasteMap;
+  _moduleResolver: ModuleResolver;
+  _resolutionCache: Map<
+    string | symbol,
+    Map<
+      string | symbol,
+      Map<string | symbol, Map<string | symbol, BundlerResolution>>
+    >
+  >;
+  _initializedPromise: Promise<void>;
   constructor(
     config: ConfigT,
     options?: {
@@ -32,7 +54,14 @@ declare class DependencyGraph extends EventEmitter {
       readonly watch?: boolean;
     },
   );
+  _onWatcherHealthCheck(result: HealthCheckResult): void;
+  _onWatcherStatus(status: WatcherStatus): void;
   ready(): Promise<void>;
+  _onHasteChange($$PARAM_0$$: ChangeEvent): void;
+  _createModuleResolver(): void;
+  _getClosestPackage(
+    absoluteModulePath: string,
+  ): null | undefined | {packageJsonPath: string; packageRelativePath: string};
   getAllFiles(): Array<string>;
   /**
    * Used when watcher.unstable_lazySha1 is true

--- a/packages/metro/types/node-haste/DependencyGraph/ModuleResolution.d.ts
+++ b/packages/metro/types/node-haste/DependencyGraph/ModuleResolution.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<2948a6737474a8f5bd55952246f500d3>>
+ * @generated SignedSource<<0024fd05b95efe19a24f9acc84ff474b>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/node-haste/DependencyGraph/ModuleResolution.js
@@ -24,7 +24,9 @@ import type {ResolverInputOptions} from '../../shared/types';
 import type {
   CustomResolver,
   DoesFileExist,
+  FileCandidates,
   FileSystemLookup,
+  Resolution,
   ResolveAsset,
 } from 'metro-resolver';
 import type {PackageForModule, PackageJson} from 'metro-resolver/private/types';
@@ -66,7 +68,11 @@ type Options = Readonly<{
   unstable_incrementalResolution: boolean;
 }>;
 export declare class ModuleResolver {
+  _options: Options;
+  _projectRootFakeModulePath: string;
+  _cachedEmptyModule: null | undefined | BundlerResolution;
   constructor(options: Options);
+  _getEmptyModule(): BundlerResolution;
   resolveDependency(
     originModulePath: string,
     dependency: TransformResultDependency,
@@ -74,6 +80,12 @@ export declare class ModuleResolver {
     platform: string | null,
     resolverOptions: ResolverInputOptions,
   ): BundlerResolution;
+  /**
+   * TODO: Return Resolution instead of coercing to BundlerResolution here
+   */
+  _getFileResolvedModule(resolution: Resolution): BundlerResolution;
+  _logWarning: (message: string) => void;
+  _removeRoot(candidates: FileCandidates): FileCandidates;
 }
 export declare class UnableToResolveError extends Error {
   /**

--- a/scripts/__tests__/ts-defs-sync-test.js
+++ b/scripts/__tests__/ts-defs-sync-test.js
@@ -17,7 +17,10 @@ import {
 test('TypeScript defs are in sync (yarn run build-ts-defs produces no changes)', async () => {
   let error;
   try {
-    await generateTsDefsForJsGlobs(AUTO_GENERATED_PATTERNS, {verifyOnly: true});
+    await generateTsDefsForJsGlobs(AUTO_GENERATED_PATTERNS, {
+      verifyOnly: true,
+      mungeUnderscores: false,
+    });
   } catch (e) {
     error = e;
   }

--- a/scripts/generateTypeScriptDefinitions.js
+++ b/scripts/generateTypeScriptDefinitions.js
@@ -61,7 +61,8 @@ export async function generateTsDefsForJsGlobs(
   globPattern: string | ReadonlyArray<string>,
   opts: Readonly<{
     verifyOnly: boolean,
-  }> = {verifyOnly: false},
+    mungeUnderscores: boolean,
+  }> = {verifyOnly: false, mungeUnderscores: false},
 ) {
   const linter = new ESLint({
     fix: true,
@@ -189,7 +190,11 @@ export async function generateTsDefsForJsGlobs(
         return;
       }
       try {
-        const flowDef = await translateFlowToFlowDef(source);
+        const flowDef = await translateFlowToFlowDef(
+          source,
+          {},
+          {mungeUnderscores: opts.mungeUnderscores},
+        );
         if (flowDef.includes('declare module.exports')) {
           errors.push({
             sourceFile,


### PR DESCRIPTION
Cherry-pick https://github.com/react/metro/pull/1876 to 0.85.x

Changelog:
```
 - **[Types]**: Restore publishing of private (underscore-prefixed) fields in TypeScript declarations
```
