### PR TITLE
[0.85] Types: Annotate `Promise<void>` returns on async functions

### DIFF
--- a/packages/buck-worker-tool/src/profiling.js
+++ b/packages/buck-worker-tool/src/profiling.js
@@ -25,7 +25,7 @@ function getInspectorSession() {
   return currentInspectorSession;
 }
 
-export async function startProfiling() {
+export async function startProfiling(): Promise<void> {
   if (isProfiling) {
     return;
   }
@@ -36,7 +36,9 @@ export async function startProfiling() {
   isProfiling = true;
 }
 
-export async function stopProfilingAndWrite(workerName: ?string) {
+export async function stopProfilingAndWrite(
+  workerName: ?string,
+): Promise<void> {
   if (!isProfiling) {
     return;
   }

--- a/packages/buck-worker-tool/types/profiling.d.ts
+++ b/packages/buck-worker-tool/types/profiling.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<ae98ee20cb59420ad8aa343e7ce31e8d>>
+ * @generated SignedSource<<09802f56d759b9edc8e6453a35bed569>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/buck-worker-tool/src/profiling.js
@@ -15,7 +15,7 @@
  *   yarn run build-ts-defs (OSS) 
  */
 
-export declare function startProfiling(): void;
+export declare function startProfiling(): Promise<void>;
 export declare function stopProfilingAndWrite(
   workerName: null | undefined | string,
-): void;
+): Promise<void>;

--- a/packages/metro-file-map/src/Watcher.js
+++ b/packages/metro-file-map/src/Watcher.js
@@ -183,7 +183,9 @@ export class Watcher extends EventEmitter {
     return delta;
   }
 
-  async watch(onChange: (change: WatcherBackendChangeEvent) => void) {
+  async watch(
+    onChange: (change: WatcherBackendChangeEvent) => void,
+  ): Promise<void> {
     const {extensions, ignorePatternForWatch, useWatchman} = this.#options;
 
     // WatchmanWatcher > NativeWatcher > FallbackWatcher
@@ -268,7 +270,7 @@ export class Watcher extends EventEmitter {
     resolveHealthCheck();
   }
 
-  async close() {
+  async close(): Promise<void> {
     await Promise.all(this.#backends.map(watcher => watcher.stopWatching()));
     this.#activeWatcher = null;
   }

--- a/packages/metro-file-map/src/watchers/NativeWatcher.js
+++ b/packages/metro-file-map/src/watchers/NativeWatcher.js
@@ -95,7 +95,7 @@ export default class NativeWatcher extends AbstractWatcher {
     }
   }
 
-  async _handleEvent(event: string, relativePath: string) {
+  async _handleEvent(event: string, relativePath: string): Promise<void> {
     const absolutePath = path.resolve(this.root, relativePath);
     if (this.doIgnore(relativePath)) {
       debug(

--- a/packages/metro-file-map/types/Watcher.d.ts
+++ b/packages/metro-file-map/types/Watcher.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<7e33ffd7eec05b9c9c072189d2ed3ec2>>
+ * @generated SignedSource<<4cbe9e53356384d92ed0fbdd4c873f7e>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/Watcher.js
@@ -67,7 +67,7 @@ export declare class Watcher extends EventEmitter {
     subpath: string,
     currentFileSystem: CrawlerOptions['previousState']['fileSystem'],
   ): Promise<CrawlResult>;
-  watch(onChange: (change: WatcherBackendChangeEvent) => void): void;
-  close(): void;
+  watch(onChange: (change: WatcherBackendChangeEvent) => void): Promise<void>;
+  close(): Promise<void>;
   checkHealth(timeout: number): Promise<HealthCheckResult>;
 }

--- a/packages/metro-file-map/types/watchers/NativeWatcher.d.ts
+++ b/packages/metro-file-map/types/watchers/NativeWatcher.d.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @noformat
- * @generated SignedSource<<b68c5620efd3f5bec83279059d0d1b4e>>
+ * @generated SignedSource<<99faac6446a910cc70728424f342908c>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro-file-map/src/watchers/NativeWatcher.js
@@ -50,6 +50,6 @@ declare class NativeWatcher extends AbstractWatcher {
    * End watching.
    */
   stopWatching(): Promise<void>;
-  _handleEvent(event: string, relativePath: string): void;
+  _handleEvent(event: string, relativePath: string): Promise<void>;
 }
 export default NativeWatcher;

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -201,7 +201,7 @@ export default class Server {
     this._nextBundleBuildNumber = 1;
   }
 
-  async end() {
+  async end(): Promise<void> {
     if (!this._isEnded) {
       await this._bundler.end();
       this._isEnded = true;

--- a/packages/metro/src/node-haste/DependencyGraph.js
+++ b/packages/metro/src/node-haste/DependencyGraph.js
@@ -284,7 +284,7 @@ export default class DependencyGraph extends EventEmitter {
     return this._haste;
   }
 
-  async end() {
+  async end(): Promise<void> {
     await this.ready();
     await this._haste.end();
   }

--- a/packages/metro/types/Server.d.ts
+++ b/packages/metro/types/Server.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<03b526801403adb05b3b0f6c25b25ed5>>
+ * @generated SignedSource<<58a8bc4229ee86a5c93af2ea51195b97>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/Server.js
@@ -120,7 +120,7 @@ declare class Server {
   _fetchTimings: Array<FetchTiming>;
   _activeFetchCount: number;
   constructor(config: ConfigT, options?: ServerOptions);
-  end(): void;
+  end(): Promise<void>;
   getBundler(): IncrementalBundler;
   getCreateModuleId(): (path: string) => number;
   _serializeGraph(

--- a/packages/metro/types/node-haste/DependencyGraph.d.ts
+++ b/packages/metro/types/node-haste/DependencyGraph.d.ts
@@ -6,7 +6,7 @@
  *
  * @noformat
  * @oncall react_native
- * @generated SignedSource<<13f1483d2a732241f8d9eae463399b0e>>
+ * @generated SignedSource<<0ae2c74336868865b420d900a230cea7>>
  *
  * This file was translated from Flow by scripts/generateTypeScriptDefinitions.js
  * Original file: packages/metro/src/node-haste/DependencyGraph.js
@@ -70,7 +70,7 @@ declare class DependencyGraph extends EventEmitter {
     mixedPath: string,
   ): Promise<{content?: Buffer; sha1: string}>;
   getWatcher(): EventEmitter;
-  end(): void;
+  end(): Promise<void>;
   /** Given a search context, return a list of file paths matching the query. */
   matchFilesWithContext(
     from: string,


### PR DESCRIPTION
Picks https://github.com/react/metro/pull/1896 to 0.85.x

Changelog:
```
 - **[Types]**: async methods including `Server#end`, `Watcher#watch`/`#close` and `DependencyGraph#end` are now correctly declared as returning `Promise<void>` rather than `void`
```