### PR TITLE
Fix mismatched asset paths in builds when using `unstable_serverRoot`

### DIFF
--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -449,9 +449,6 @@ export default class Server {
       processModuleFilter: this._config.serializer.processModuleFilter,
       assetPlugins: this._config.transformer.assetPlugins,
       platform,
-      // Asset URLs are anchored on projectRoot, not the server root: the
-      // /assets endpoint resolves a bare relative path against projectRoot,
-      // and [metro-project] means projectRoot in _sourceRequestRoutingMap.
       projectRoot: this._config.projectRoot,
       publicPath: this._config.transformer.publicPath,
     });

--- a/packages/metro/src/Server.js
+++ b/packages/metro/src/Server.js
@@ -449,7 +449,10 @@ export default class Server {
       processModuleFilter: this._config.serializer.processModuleFilter,
       assetPlugins: this._config.transformer.assetPlugins,
       platform,
-      projectRoot: this._getServerRootDir(),
+      // Asset URLs are anchored on projectRoot, not the server root: the
+      // /assets endpoint resolves a bare relative path against projectRoot,
+      // and [metro-project] means projectRoot in _sourceRequestRoutingMap.
+      projectRoot: this._config.projectRoot,
       publicPath: this._config.transformer.publicPath,
     });
   }
@@ -1369,13 +1372,10 @@ export default class Server {
         {onProgress, shallow: false, lazy: false},
       );
 
-      return await getAssets(dependencies, {
-        processModuleFilter: this._config.serializer.processModuleFilter,
-        assetPlugins: this._config.transformer.assetPlugins,
-        platform: transformOptions.platform,
-        publicPath: this._config.transformer.publicPath,
-        projectRoot: this._config.projectRoot,
-      });
+      return await this._getAssetsFromDependencies(
+        dependencies,
+        transformOptions.platform,
+      );
     },
     finish({mres, result}) {
       mres.setHeader('Content-Type', 'application/json');

--- a/packages/metro/src/Server/__tests__/Server-test.js
+++ b/packages/metro/src/Server/__tests__/Server-test.js
@@ -63,6 +63,7 @@ describe('processRequest', () => {
   let getTransformFn;
   let getResolveDependencyFn;
   let getAsset;
+  let getAssetsSerializer;
 
   beforeEach(() => {
     jest.resetModules();
@@ -76,6 +77,7 @@ describe('processRequest', () => {
     getTransformFn = jest.fn();
     getResolveDependencyFn = jest.fn();
     getAsset = jest.fn();
+    getAssetsSerializer = jest.fn().mockResolvedValue([]);
 
     let i = 0;
     jest.doMock('node:crypto', () => ({
@@ -113,6 +115,11 @@ describe('processRequest', () => {
       .spyOn(DeltaBundler.prototype, 'buildGraph')
       .mockImplementation(buildGraph);
     jest.spyOn(DeltaBundler.prototype, 'getDelta').mockImplementation(getDelta);
+
+    jest.doMock('../../DeltaBundler/Serializers/getAssets', () => ({
+      __esModule: true,
+      default: getAssetsSerializer,
+    }));
 
     Server = require('../../Server').default;
   });
@@ -1519,6 +1526,24 @@ describe('processRequest', () => {
         expect(errorSpy).not.toBeCalled();
       },
     );
+  });
+
+  describe('asset URL roots', () => {
+    test('anchors asset URLs on projectRoot, not unstable_serverRoot', async () => {
+      // $FlowFixMe[unclear-type] - reaching for a private method under test.
+      const serverRootServer: any = new Server(
+        mergeConfig(config, {
+          server: {unstable_serverRoot: '/'},
+        } as InputConfigT),
+      );
+
+      await serverRootServer._getAssetsFromDependencies(new Map(), 'ios');
+
+      expect(getAssetsSerializer).toBeCalledWith(
+        expect.anything(),
+        expect.objectContaining({projectRoot: '/root'}),
+      );
+    });
   });
 
   describe('watchFolder prefix resolution', () => {


### PR DESCRIPTION
## Context

When Metro sees `require('./imgs/logo.png')` in userland source it synthesises a JS module representing `./imgs/logo.png` that encodes includes everything needed to _find_ the asset, roughly:

```
{name: "logo", ext: "png", scales: [1, 2], hash: "abc123", httpServerLocation: "/assets/imgs"}
```

In a dev server build, the client rebuilds a URL from this information and asks Metro for the file:

```
http://localhost:8081/assets/imgs/logo@2x.png?platform=ios&hash=abc123
```

In a "release" build (more correctly - any CLI-driven build not served from the dev server, but this is typically used for (and only for) release builds), typically, frameworks use Metro's `saveAssets`, which copies each file to a **path derived from `httpServerLocation`** (even though no http server is used) at build time:

```
iOS:      /assets/imgs  ->  assets/imgs/logo.png, assets/imgs/logo@2x.png
Android:  /assets/imgs  ->  drawable-mdpi/imgs_logo.png, drawable-xhdpi/imgs_logo.png
```

and at runtime `AssetSourceResolver` derives the lookup path from `httpServerLocation`, by the same rules. **Both halves have to agree.**

## Summary

`httpServerLocation` is computed twice, from two different roots. The transformer computes it per module relative to `projectRoot` and bakes it into the bundle - that's what the client uses to find an asset at runtime, in both dev and prod. The `getAssets` serialiser (for prod) computes it again over the whole graph relative to `unstable_serverRoot`, and that's what `saveAssets` uses to place files for `--assets-dest`.

So if `unstable_serverRoot` is set, `Server.getAssets()` and `Server.build(<...>, {withAssets: true})` result in asset paths that do not match the JS bundle. Eg, for `unstable_serverRoot` set to a workspace root, and `projectRoot` set to the subdir `app`, the release build writes (conceptually) `assets/app/assets/logo.png` but the runtime looks for `assets/assets/logo.png`.

Dev is unaffected, because there both halves of the lookup come from the transformer's copy.

This dates to the original `unstable_serverRoot` change, which applied the server root broadly across `Server` and took this call site with it while both readers stayed on `projectRoot`. It was obviously never really tested - `unstable_serverRoot` is/was used at Meta but the release assets pipeline via Metro-Buck is completely different.

The main motivation for this now is *not* to make it easier to use `unstable_serverRoot`, which probably should not exist, but to make asset path calculation consistent, allowing us to build on that to **fix assets outside `projectRoot`** - that's the follow up #1892.

Changelog:
```
 - **[Experimental]**: Fix mismatched asset paths in (release) builds under `unstable_serverRoot`, make them always relative to `projectRoot`.
```

## Expo

No immediate impact. Expo is the main setter of `unstable_serverRoot` - `@expo/metro-config` points it at the workspace root. Expo already applies exactly this fix in our fork of the assets path - expo/expo#25312, since 2023.

So this fix in core removes one of the reasons Expo's fork has to exist.

## Community CLI

No impact - `unstable_serverRoot` (thankfully) remains completely unmentioned in RN or RNC/CLI.

## Test plan

### Unit

New test pins `_getAssetsFromDependencies` to `projectRoot` with `unstable_serverRoot` set to `/`. Restoring `_getServerRootDir()` fails it:

```console
$ yarn jest packages/metro/src/Server
  ✕ anchors asset URLs on projectRoot, not unstable_serverRoot
Tests: 1 failed, 83 passed, 84 total
```

### End to end

Built a React Native 0.87.1 app in a Yarn workspace, with an asset directory peer to the app root and `server.unstable_serverRoot` pointed at the workspace root:

```text
workspace/
├── media/          peer-logo.png, peer-logo@2x.png, peer-logo.ios.png, peer-logo@2x.ios.png
└── app/            projectRoot; watchFolders: [workspaceRoot]
    └── assets/     in-project.png, in-project@2x.png, in-project.ios.png, in-project@2x.ios.png
```

`react-native bundle --platform ios --dev false --entry-file app/index.js --assets-dest …` on `main` produces the four-way mismatch shown under "The problem" above: the JS bundle carries `/assets/assets` and `/assets/../media` from the transformer, while the copied files land under `assets/app/assets/` and `assets/media/` from `getAssets`.

Running `Metro.runBuild` with `assets: true` against the same config, at each revision, and passing the resulting `AssetData` through React Native 0.87.1's own `getAssetDestPathIOS` / `getAssetDestPathAndroid` / `filterPlatformAssetScales` - the three functions `saveAssets` uses to implement `--assets-dest`:

```text
                       getAssets says        destination
main                   /assets/app/assets    assets/app/assets/in-project.png
                       /assets/media         assets/media/peer-logo.png
this PR                /assets/assets        assets/assets/in-project.png
                       /assets/../media      assets/_media/peer-logo.png
```

Comparing each against what the runtime derives from the bundle's copy:

```text
in-project   main      iOS MISMATCH   Android MISMATCH
             this PR   iOS MATCH      Android MATCH
peer-logo    main      iOS MISMATCH   Android MISMATCH
             this PR   iOS MATCH      Android MATCH
```

The peer asset matches without the `[metro-watchFolders]` change stacked on top, because `getAssetDestPathIOS` and `scaledAssetURLNearBundle` apply the same `../` to `_` rewrite independently. An ugly filename, but a working image.

The "this PR" destinations are computed from the verified `getAssets` output fed through React Native's real helpers, rather than from a `react-native bundle` run against a patched Metro.

Against a running dev server, the URLs `main` produces do not resolve at the endpoint meant to serve them, and this PR's do:

```console
$ curl -o /dev/null -w '%{http_code}' '/assets/app/assets/in-project.png?platform=ios'   # main
404
$ curl -o /dev/null -w '%{http_code}' '/assets/media/peer-logo.png?platform=ios'         # main
404
$ curl -o /dev/null -w '%{http_code}' '/assets/assets/in-project.png?platform=ios'       # this PR
200
$ curl -o /dev/null -w '%{http_code}' '/assets/../media/peer-logo.png?platform=ios'      # this PR
200
```

### Checks

Run on this commit alone, not on the stack:

```console
$ yarn jest packages/metro/src
Test Suites: 61 passed, 61 total
Tests:       1 skipped, 869 passed, 870 total

$ yarn flow check
$ yarn typecheck-ts
$ yarn verify-api-snapshots
$ yarn lint
```
