### PR TITLE
Exclude React Native native build output by default

### DIFF
--- a/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
+++ b/packages/metro-config/src/defaults/__tests__/exclusionList-test.js
@@ -30,6 +30,18 @@ describe('exclusionList', () => {
     path.sep = originalSeparator;
   });
 
+  const asPlatformPath = (filepath: string) =>
+    filepath.replaceAll('/', path.sep);
+
+  const nativeBuildOutputPaths = [
+    '.cxx',
+    'android/.gradle',
+    'android/build',
+    'android/app/build',
+    'ios/build',
+    'ios/DerivedData',
+  ];
+
   test('proves we can write to path.sep for setting up the tests', () => {
     setPathSeperator('/');
     expect(require('node:path').sep).toBe('/');
@@ -71,6 +83,25 @@ describe('exclusionList', () => {
       );
       expect('/foo/bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
     });
+
+    test.each(nativeBuildOutputPaths)(
+      'excludes React Native native build output %s',
+      buildOutputPath => {
+        const exclusion = exclusionList();
+
+        expect(asPlatformPath(buildOutputPath)).toMatch(exclusion);
+        expect(asPlatformPath(`${buildOutputPath}/generated/file.o`)).toMatch(
+          exclusion,
+        );
+      },
+    );
+
+    test('does not exclude adjacent source paths', () => {
+      const exclusion = exclusionList();
+
+      expect('src/android/app.js').not.toMatch(exclusion);
+      expect('src/ios/DerivedDataExample.js').not.toMatch(exclusion);
+    });
   });
 
   describe('simulate windows enviornment', () => {
@@ -106,6 +137,27 @@ describe('exclusionList', () => {
         exclusionList([new RegExp('.*[\\/\\\\]foo[\\/\\\\]bar')]),
       );
       expect('\\foo\\bar').toMatch(exclusionList([/.*[\/\\]foo[\/\\]bar/]));
+    });
+
+    test.each(nativeBuildOutputPaths)(
+      'excludes React Native native build output %s',
+      buildOutputPath => {
+        const exclusion = exclusionList();
+
+        expect(asPlatformPath(buildOutputPath)).toMatch(exclusion);
+        expect(asPlatformPath(`${buildOutputPath}/generated/file.o`)).toMatch(
+          exclusion,
+        );
+      },
+    );
+
+    test('does not exclude adjacent source paths', () => {
+      const exclusion = exclusionList();
+
+      expect(asPlatformPath('src/android/app.js')).not.toMatch(exclusion);
+      expect(asPlatformPath('src/ios/DerivedDataExample.js')).not.toMatch(
+        exclusion,
+      );
     });
   });
 });

--- a/packages/metro-config/src/defaults/exclusionList.js
+++ b/packages/metro-config/src/defaults/exclusionList.js
@@ -11,7 +11,15 @@
 
 import path from 'node:path';
 
-const list = [/\/__tests__\/.*/];
+const list = [
+  /\/__tests__\/.*/,
+  /(^|\/)\.cxx($|\/.*)/,
+  /(^|\/)android\/\.gradle($|\/.*)/,
+  /(^|\/)android\/build($|\/.*)/,
+  /(^|\/)android\/app\/build($|\/.*)/,
+  /(^|\/)ios\/build($|\/.*)/,
+  /(^|\/)ios\/DerivedData($|\/.*)/,
+];
 
 function escapeRegExp(pattern: RegExp | string) {
   if (pattern instanceof RegExp) {


### PR DESCRIPTION
## Summary

Fixes #1915 by adding Metro's default exclusions for React Native native build outputs that should not be watched: `.cxx`, Android Gradle/build directories, iOS build output, and iOS DerivedData.

Changelog: [Fix] Exclude React Native native build output from Metro's default file map

## Test plan

- `npx -y yarn@1.22.22 jest packages/metro-config/src/defaults/__tests__/exclusionList-test.js --runInBand`
- `npx eslint packages/metro-config/src/defaults/exclusionList.js packages/metro-config/src/defaults/__tests__/exclusionList-test.js --cache`
- `npx prettier --check packages/metro-config/src/defaults/exclusionList.js packages/metro-config/src/defaults/__tests__/exclusionList-test.js`
- `git diff --check`

`yarn run typecheck` could not run locally because the Flow binary requires GLIBC_2.29+ on this host.
